### PR TITLE
Add out-of-band blocked-query metadata for query loggers

### DIFF
--- a/Apps/AdvancedBlockingApp/App.cs
+++ b/Apps/AdvancedBlockingApp/App.cs
@@ -605,6 +605,31 @@ namespace AdvancedBlocking
                 return blockingReport;
             }
 
+            DnsQueryLogMetadata GetMetadata()
+            {
+                string? reference = blockListUrl?.Uri?.AbsoluteUri;
+
+                Dictionary<string, string> additionalData = new Dictionary<string, string>
+                {
+                    ["group"] = group.Name
+                };
+
+                if (blockedRegex is null)
+                    additionalData["domain"] = blockedDomain!;
+                else
+                    additionalData["regex"] = blockedRegex;
+
+                return new DnsQueryLogMetadata
+                {
+                    Source = "AdvancedBlockingApp",
+                    Reason = "advanced-blocking-app",
+                    Reference = reference,
+                    AdditionalData = additionalData
+                };
+            }
+
+            DnsServerResponseMetadata metadataTag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, GetMetadata());
+
             if (group.AllowTxtBlockingReport && (question.Type == DnsResourceRecordType.TXT))
             {
                 //return meta data
@@ -612,7 +637,7 @@ namespace AdvancedBlocking
 
                 DnsResourceRecord[] answer = [new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, _blockingAnswerTtl, new DnsTXTRecordData(blockingReport))];
 
-                return Task.FromResult<DnsDatagram?>(new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer));
+                return Task.FromResult<DnsDatagram?>(new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer) { Tag = metadataTag });
             }
             else
             {
@@ -697,7 +722,7 @@ namespace AdvancedBlocking
                     }
                 }
 
-                return Task.FromResult<DnsDatagram?>(new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, rcode, request.Question, answer, authority, null, request.EDNS is null ? ushort.MinValue : _dnsServer!.UdpPayloadSize, EDnsHeaderFlags.None, options));
+                return Task.FromResult<DnsDatagram?>(new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, rcode, request.Question, answer, authority, null, request.EDNS is null ? ushort.MinValue : _dnsServer!.UdpPayloadSize, EDnsHeaderFlags.None, options) { Tag = metadataTag });
             }
         }
 

--- a/Apps/AdvancedBlockingApp/App.cs
+++ b/Apps/AdvancedBlockingApp/App.cs
@@ -628,7 +628,7 @@ namespace AdvancedBlocking
                 };
             }
 
-            DnsServerResponseMetadata metadataTag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, GetMetadata());
+            DnsResponseTag metadataTag = new DnsResponseTag { ResponseType = DnsServerResponseType.Blocked, Metadata = GetMetadata() };
 
             if (group.AllowTxtBlockingReport && (question.Type == DnsResourceRecordType.TXT))
             {

--- a/Apps/LogExporterApp/App.cs
+++ b/Apps/LogExporterApp/App.cs
@@ -31,7 +31,7 @@ using TechnitiumLibrary.Net.Dns;
 
 namespace LogExporter
 {
-    public sealed class App : IDnsApplication, IDnsQueryLogger
+    public sealed class App : IDnsApplication, IDnsQueryLoggerEx
     {
         #region variables
 
@@ -139,10 +139,15 @@ namespace LogExporter
 
         public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response)
         {
+            return InsertLogAsync(timestamp, request, remoteEP, protocol, response, null);
+        }
+
+        public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata)
+        {
             if (_enableLogging)
             {
                 if (_queuedLogs.Count < _config!.MaxQueueSize)
-                    _queuedLogs.Enqueue(new LogEntry(timestamp, remoteEP, protocol, request, response, _config.EnableEdnsLogging));
+                    _queuedLogs.Enqueue(new LogEntry(timestamp, remoteEP, protocol, request, response, _config.EnableEdnsLogging, metadata));
             }
 
             return Task.CompletedTask;

--- a/Apps/LogExporterApp/App.cs
+++ b/Apps/LogExporterApp/App.cs
@@ -31,7 +31,7 @@ using TechnitiumLibrary.Net.Dns;
 
 namespace LogExporter
 {
-    public sealed class App : IDnsApplication, IDnsQueryLoggerEx
+    public sealed class App : IDnsApplication, IDnsQueryLogger
     {
         #region variables
 
@@ -137,12 +137,7 @@ namespace LogExporter
             return Task.CompletedTask;
         }
 
-        public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response)
-        {
-            return InsertLogAsync(timestamp, request, remoteEP, protocol, response, null);
-        }
-
-        public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata)
+        public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata = null)
         {
             if (_enableLogging)
             {

--- a/Apps/LogExporterApp/LogEntry.cs
+++ b/Apps/LogExporterApp/LogEntry.cs
@@ -42,7 +42,7 @@ namespace LogExporter
             ClientIp = remoteEP.Address.ToString();
             Protocol = protocol;
             ResponseType = DnsServerResponseTag.GetResponseType(response.Tag);
-            BlockingReport = metadata?.BlockingReport;
+            BlockingMetadata = metadata?.Values;
 
             if ((ResponseType == DnsServerResponseType.Recursive) && (response.Metadata is not null))
                 ResponseRtt = response.Metadata.RoundTripTime;
@@ -97,7 +97,7 @@ namespace LogExporter
 
         public List<DnsResourceRecord> Answers { get; private set; }
         public string ClientIp { get; private set; }
-        public string? BlockingReport { get; private set; }
+        public IReadOnlyDictionary<string, string>? BlockingMetadata { get; private set; }
         public List<EDNSLog> EDNS { get; private set; }
         public DnsTransportProtocol Protocol { get; private set; }
         public DnsQuestion? Question { get; private set; }

--- a/Apps/LogExporterApp/LogEntry.cs
+++ b/Apps/LogExporterApp/LogEntry.cs
@@ -43,10 +43,14 @@ namespace LogExporter
             Protocol = protocol;
             ResponseType = DnsServerResponseTag.GetResponseType(response.Tag);
 
+            // Populate blocking metadata when provided
             if (metadata is not null)
-                BlockingMetadata = metadata.Values.Count > 0 ? metadata.Values : null;
-            else if (ResponseType is DnsServerResponseType.Blocked or DnsServerResponseType.UpstreamBlocked or DnsServerResponseType.UpstreamBlockedCached)
-                BlockingMetadata = ExtractInlineBlockingMetadata(response)?.Values;
+            {
+                BlockingSource = metadata.Source;
+                BlockingReason = metadata.Reason;
+                BlockingReference = metadata.Reference;
+                BlockingAdditionalData = metadata.AdditionalData;
+            }
 
             if ((ResponseType == DnsServerResponseType.Recursive) && (response.Metadata is not null))
                 ResponseRtt = response.Metadata.RoundTripTime;
@@ -100,8 +104,11 @@ namespace LogExporter
         }
 
         public List<DnsResourceRecord> Answers { get; private set; }
+        public IReadOnlyDictionary<string, string>? BlockingAdditionalData { get; private set; }
+        public string? BlockingReason { get; private set; }
+        public string? BlockingReference { get; private set; }
+        public string? BlockingSource { get; private set; }
         public string ClientIp { get; private set; }
-        public IReadOnlyDictionary<string, string>? BlockingMetadata { get; private set; }
         public List<EDNSLog> EDNS { get; private set; }
         public DnsTransportProtocol Protocol { get; private set; }
         public DnsQuestion? Question { get; private set; }
@@ -112,33 +119,6 @@ namespace LogExporter
         public override string ToString()
         {
             return JsonSerializer.Serialize(this, DnsLogSerializerOptions.Default);
-        }
-
-        private static DnsQueryLogMetadata? ExtractInlineBlockingMetadata(DnsDatagram response)
-        {
-            foreach (DnsResourceRecord answer in response.Answer)
-            {
-                if (answer.Type == DnsResourceRecordType.TXT && answer.RDATA is DnsTXTRecordData txtData)
-                {
-                    string txt = txtData.ToString();
-                    if (txt.Contains("source=", StringComparison.Ordinal))
-                        return DnsQueryLogMetadata.ParseReportString(txt);
-                }
-            }
-
-            if (response.EDNS is not null)
-            {
-                foreach (EDnsOption option in response.EDNS.Options)
-                {
-                    if (option.Code == EDnsOptionCode.EXTENDED_DNS_ERROR &&
-                        option.Data is EDnsExtendedDnsErrorOptionData ede &&
-                        ede.InfoCode == EDnsExtendedDnsErrorCode.Blocked &&
-                        ede.ExtraText is not null)
-                        return DnsQueryLogMetadata.ParseReportString(ede.ExtraText);
-                }
-            }
-
-            return null;
         }
 
         public static class DnsLogSerializerOptions

--- a/Apps/LogExporterApp/LogEntry.cs
+++ b/Apps/LogExporterApp/LogEntry.cs
@@ -33,7 +33,7 @@ namespace LogExporter
 {
     public class LogEntry
     {
-        public LogEntry(DateTime timestamp, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram request, DnsDatagram response, bool ednsLogging = false)
+        public LogEntry(DateTime timestamp, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram request, DnsDatagram response, bool ednsLogging = false, DnsQueryLogMetadata? metadata = null)
         {
             // Assign timestamp and ensure it's in UTC
             Timestamp = timestamp.Kind == DateTimeKind.Utc ? timestamp : timestamp.ToUniversalTime();
@@ -41,7 +41,8 @@ namespace LogExporter
             // Extract client information
             ClientIp = remoteEP.Address.ToString();
             Protocol = protocol;
-            ResponseType = response.Tag == null ? DnsServerResponseType.Recursive : (DnsServerResponseType)response.Tag;
+            ResponseType = DnsServerResponseTag.GetResponseType(response.Tag);
+            BlockingReport = metadata?.BlockingReport;
 
             if ((ResponseType == DnsServerResponseType.Recursive) && (response.Metadata is not null))
                 ResponseRtt = response.Metadata.RoundTripTime;
@@ -96,6 +97,7 @@ namespace LogExporter
 
         public List<DnsResourceRecord> Answers { get; private set; }
         public string ClientIp { get; private set; }
+        public string? BlockingReport { get; private set; }
         public List<EDNSLog> EDNS { get; private set; }
         public DnsTransportProtocol Protocol { get; private set; }
         public DnsQuestion? Question { get; private set; }

--- a/Apps/LogExporterApp/LogEntry.cs
+++ b/Apps/LogExporterApp/LogEntry.cs
@@ -42,7 +42,11 @@ namespace LogExporter
             ClientIp = remoteEP.Address.ToString();
             Protocol = protocol;
             ResponseType = DnsServerResponseTag.GetResponseType(response.Tag);
-            BlockingMetadata = metadata?.Values;
+
+            if (metadata is not null)
+                BlockingMetadata = metadata.Values.Count > 0 ? metadata.Values : null;
+            else if (ResponseType is DnsServerResponseType.Blocked or DnsServerResponseType.UpstreamBlocked or DnsServerResponseType.UpstreamBlockedCached)
+                BlockingMetadata = ExtractInlineBlockingMetadata(response)?.Values;
 
             if ((ResponseType == DnsServerResponseType.Recursive) && (response.Metadata is not null))
                 ResponseRtt = response.Metadata.RoundTripTime;
@@ -108,6 +112,33 @@ namespace LogExporter
         public override string ToString()
         {
             return JsonSerializer.Serialize(this, DnsLogSerializerOptions.Default);
+        }
+
+        private static DnsQueryLogMetadata? ExtractInlineBlockingMetadata(DnsDatagram response)
+        {
+            foreach (DnsResourceRecord answer in response.Answer)
+            {
+                if (answer.Type == DnsResourceRecordType.TXT && answer.RDATA is DnsTXTRecordData txtData)
+                {
+                    string txt = txtData.ToString();
+                    if (txt.Contains("source=", StringComparison.Ordinal))
+                        return DnsQueryLogMetadata.ParseReportString(txt);
+                }
+            }
+
+            if (response.EDNS is not null)
+            {
+                foreach (EDnsOption option in response.EDNS.Options)
+                {
+                    if (option.Code == EDnsOptionCode.EXTENDED_DNS_ERROR &&
+                        option.Data is EDnsExtendedDnsErrorOptionData ede &&
+                        ede.InfoCode == EDnsExtendedDnsErrorCode.Blocked &&
+                        ede.ExtraText is not null)
+                        return DnsQueryLogMetadata.ParseReportString(ede.ExtraText);
+                }
+            }
+
+            return null;
         }
 
         public static class DnsLogSerializerOptions

--- a/Apps/LogExporterApp/LogEntry.cs
+++ b/Apps/LogExporterApp/LogEntry.cs
@@ -41,7 +41,7 @@ namespace LogExporter
             // Extract client information
             ClientIp = remoteEP.Address.ToString();
             Protocol = protocol;
-            ResponseType = DnsServerResponseTag.GetResponseType(response.Tag);
+            ResponseType = DnsResponseTag.GetResponseType(response.Tag);
 
             // Populate blocking metadata when provided
             if (metadata is not null)

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -151,15 +151,19 @@ namespace MispConnector
 
             string blockingReport = $"source=misp-connector;domain={blockedDomain}";
 
-            DnsServerResponseMetadata metadataTag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, new DnsQueryLogMetadata
+            DnsResponseTag metadataTag = new DnsResponseTag
             {
-                Source = "MispConnectorApp",
-                Reason = "misp-connector",
-                AdditionalData = new Dictionary<string, string>
+                ResponseType = DnsServerResponseType.Blocked,
+                Metadata = new DnsQueryLogMetadata
                 {
-                    ["domain"] = blockedDomain
+                    Source = "MispConnector",
+                    Reason = "misp-connector",
+                    AdditionalData = new Dictionary<string, string>
+                    {
+                        ["domain"] = blockedDomain
+                    }
                 }
-            });
+            };
 
             EDnsOption[] options = null;
             if (_config.AddExtendedDnsError && request.EDNS is not null)

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -151,6 +151,16 @@ namespace MispConnector
 
             string blockingReport = $"source=misp-connector;domain={blockedDomain}";
 
+            DnsServerResponseMetadata metadataTag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, new DnsQueryLogMetadata
+            {
+                Source = "MispConnectorApp",
+                Reason = "misp-connector",
+                AdditionalData = new Dictionary<string, string>
+                {
+                    ["domain"] = blockedDomain
+                }
+            });
+
             EDnsOption[] options = null;
             if (_config.AddExtendedDnsError && request.EDNS is not null)
             {
@@ -178,7 +188,7 @@ namespace MispConnector
                                     udpPayloadSize: request.EDNS is null ? ushort.MinValue : _dnsServer.UdpPayloadSize,
                                     ednsFlags: EDnsHeaderFlags.None,
                                     options: options
-                                ));
+                                ) { Tag = metadataTag });
             }
 
             DnsResourceRecord[] authority = { new DnsResourceRecord(question.Name, DnsResourceRecordType.SOA, question.Class, 60, _soaRecord) };
@@ -200,7 +210,7 @@ namespace MispConnector
                             udpPayloadSize: request.EDNS is null ? ushort.MinValue : _dnsServer.UdpPayloadSize,
                             ednsFlags: EDnsHeaderFlags.None,
                             options: options
-                        ));
+                        ) { Tag = metadataTag });
         }
 
         #endregion public

--- a/Apps/QueryLogsMySqlApp/App.cs
+++ b/Apps/QueryLogsMySqlApp/App.cs
@@ -660,7 +660,7 @@ CREATE TABLE IF NOT EXISTS dns_logs
             }
         }
 
-        public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response)
+        public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata = null)
         {
             if (_enableLogging)
                 _channelWriter?.TryWrite(new LogEntry(timestamp, request, remoteEP, protocol, response));

--- a/Apps/QueryLogsMySqlApp/App.cs
+++ b/Apps/QueryLogsMySqlApp/App.cs
@@ -248,12 +248,7 @@ namespace QueryLogsMySql
                             paramClientIp.Value = log.RemoteEP.Address.ToString();
                             paramProtocol.Value = (byte)log.Protocol;
 
-                            DnsServerResponseType responseType;
-
-                            if (log.Response.Tag == null)
-                                responseType = DnsServerResponseType.Recursive;
-                            else
-                                responseType = (DnsServerResponseType)log.Response.Tag;
+                            DnsServerResponseType responseType = DnsServerResponseTag.GetResponseType(log.Response.Tag);
 
                             paramResponseType.Value = (byte)responseType;
 

--- a/Apps/QueryLogsMySqlApp/App.cs
+++ b/Apps/QueryLogsMySqlApp/App.cs
@@ -248,7 +248,7 @@ namespace QueryLogsMySql
                             paramClientIp.Value = log.RemoteEP.Address.ToString();
                             paramProtocol.Value = (byte)log.Protocol;
 
-                            DnsServerResponseType responseType = DnsServerResponseTag.GetResponseType(log.Response.Tag);
+                            DnsServerResponseType responseType = DnsResponseTag.GetResponseType(log.Response.Tag);
 
                             paramResponseType.Value = (byte)responseType;
 

--- a/Apps/QueryLogsSqlServerApp/App.cs
+++ b/Apps/QueryLogsSqlServerApp/App.cs
@@ -556,7 +556,7 @@ END
             }
         }
 
-        public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response)
+        public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata = null)
         {
             if (_enableLogging)
                 _channelWriter?.TryWrite(new LogEntry(timestamp, request, remoteEP, protocol, response));

--- a/Apps/QueryLogsSqlServerApp/App.cs
+++ b/Apps/QueryLogsSqlServerApp/App.cs
@@ -249,7 +249,7 @@ namespace QueryLogsSqlServer
                             paramClientIp.Value = log.RemoteEP.Address.ToString();
                             paramProtocol.Value = (byte)log.Protocol;
 
-                            DnsServerResponseType responseType = DnsServerResponseTag.GetResponseType(log.Response.Tag);
+                            DnsServerResponseType responseType = DnsResponseTag.GetResponseType(log.Response.Tag);
 
                             paramResponseType.Value = (byte)responseType;
 

--- a/Apps/QueryLogsSqlServerApp/App.cs
+++ b/Apps/QueryLogsSqlServerApp/App.cs
@@ -249,12 +249,7 @@ namespace QueryLogsSqlServer
                             paramClientIp.Value = log.RemoteEP.Address.ToString();
                             paramProtocol.Value = (byte)log.Protocol;
 
-                            DnsServerResponseType responseType;
-
-                            if (log.Response.Tag == null)
-                                responseType = DnsServerResponseType.Recursive;
-                            else
-                                responseType = (DnsServerResponseType)log.Response.Tag;
+                            DnsServerResponseType responseType = DnsServerResponseTag.GetResponseType(log.Response.Tag);
 
                             paramResponseType.Value = (byte)responseType;
 

--- a/Apps/QueryLogsSqliteApp/App.cs
+++ b/Apps/QueryLogsSqliteApp/App.cs
@@ -245,7 +245,7 @@ namespace QueryLogsSqlite
                                 paramClientIp.Value = log.RemoteEP.Address.ToString();
                                 paramProtocol.Value = (int)log.Protocol;
 
-                                DnsServerResponseType responseType = DnsServerResponseTag.GetResponseType(log.Response.Tag);
+                                DnsServerResponseType responseType = DnsResponseTag.GetResponseType(log.Response.Tag);
 
                                 paramResponseType.Value = (int)responseType;
 

--- a/Apps/QueryLogsSqliteApp/App.cs
+++ b/Apps/QueryLogsSqliteApp/App.cs
@@ -245,12 +245,7 @@ namespace QueryLogsSqlite
                                 paramClientIp.Value = log.RemoteEP.Address.ToString();
                                 paramProtocol.Value = (int)log.Protocol;
 
-                                DnsServerResponseType responseType;
-
-                                if (log.Response.Tag == null)
-                                    responseType = DnsServerResponseType.Recursive;
-                                else
-                                    responseType = (DnsServerResponseType)log.Response.Tag;
+                                DnsServerResponseType responseType = DnsServerResponseTag.GetResponseType(log.Response.Tag);
 
                                 paramResponseType.Value = (int)responseType;
 

--- a/Apps/QueryLogsSqliteApp/App.cs
+++ b/Apps/QueryLogsSqliteApp/App.cs
@@ -517,7 +517,7 @@ CREATE TABLE IF NOT EXISTS dns_logs
             }
         }
 
-        public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response)
+        public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata = null)
         {
             if (_enableLogging)
                 _channelWriter?.TryWrite(new LogEntry(timestamp, request, remoteEP, protocol, response));

--- a/DnsServerCore.ApplicationCommon/IDnsQueryLogger.cs
+++ b/DnsServerCore.ApplicationCommon/IDnsQueryLogger.cs
@@ -19,64 +19,42 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using TechnitiumLibrary.Net.Dns;
 
 namespace DnsServerCore.ApplicationCommon
 {
+    /// <summary>
+    /// Optional out-of-band metadata attached to a DNS response by the component that handled the
+    /// request (e.g., a built-in blocking zone or a DNS App plug-in).  This object does not affect
+    /// the DNS wire format and is only visible to <see cref="IDnsQueryLogger"/> implementations.
+    /// </summary>
     public sealed class DnsQueryLogMetadata
     {
-        public DnsQueryLogMetadata(IReadOnlyDictionary<string, string>? values = null)
-        {
-            Values = values is null ? new Dictionary<string, string>(0) : new Dictionary<string, string>(values, StringComparer.OrdinalIgnoreCase);
-        }
+        /// <summary>
+        /// Identifies the component that produced this response.
+        /// Examples: <c>"blocked-zone"</c>, <c>"block-list-zone"</c>, <c>"AdvancedBlockingApp"</c>.
+        /// </summary>
+        public string? Source { get; init; }
 
         /// <summary>
-        /// Structured metadata key/value pairs (example keys: <c>source</c>, <c>domain</c>, <c>blockListUrl</c>).
+        /// Human-readable reason the request was handled in a special way, e.g. the matched domain
+        /// or a short description such as <c>"regex match"</c>.
         /// </summary>
-        public IReadOnlyDictionary<string, string> Values { get; }
+        public string? Reason { get; init; }
 
-        public string ToReportString()
-        {
-            if (Values.Count < 1)
-                return string.Empty;
+        /// <summary>
+        /// Optional reference that provides additional context, such as a block-list URL or a
+        /// rule identifier.
+        /// </summary>
+        public string? Reference { get; init; }
 
-            return string.Join("; ", Values.Select(kv => kv.Key + "=" + kv.Value));
-        }
-
-        public static DnsQueryLogMetadata? ParseReportString(string? report)
-        {
-            if (string.IsNullOrWhiteSpace(report))
-                return null;
-
-            string[] parts = report.Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length < 1)
-                return null;
-
-            Dictionary<string, string> values = new Dictionary<string, string>(parts.Length, StringComparer.OrdinalIgnoreCase);
-
-            foreach (string part in parts)
-            {
-                int separatorIndex = part.IndexOf('=');
-                if ((separatorIndex < 1) || (separatorIndex >= (part.Length - 1)))
-                    continue;
-
-                string key = part[..separatorIndex].Trim();
-                string value = part[(separatorIndex + 1)..].Trim();
-
-                if ((key.Length < 1) || (value.Length < 1))
-                    continue;
-
-                values[key] = value;
-            }
-
-            if (values.Count < 1)
-                return null;
-
-            return new DnsQueryLogMetadata(values);
-        }
+        /// <summary>
+        /// Non-hardcoded supplementary fields supplied by the source component.
+        /// Keys are case-insensitive.  May be <see langword="null"/> when no extra data is present.
+        /// </summary>
+        public IReadOnlyDictionary<string, string>? AdditionalData { get; init; }
     }
 
     public sealed class DnsServerResponseMetadata
@@ -133,30 +111,19 @@ namespace DnsServerCore.ApplicationCommon
     public interface IDnsQueryLogger
     {
         /// <summary>
-        /// Allows a DNS App to log incoming DNS requests and responses. This method is called by the DNS Server after an incoming request is processed and a response is sent.
+        /// Allows a DNS App to log incoming DNS requests and responses. This method is called by
+        /// the DNS Server after an incoming request is processed and a response is sent.
         /// </summary>
         /// <param name="timestamp">The time stamp of the log entry.</param>
         /// <param name="request">The incoming DNS request that was received.</param>
         /// <param name="remoteEP">The end point (IP address and port) of the client making the request.</param>
         /// <param name="protocol">The protocol using which the request was received.</param>
         /// <param name="response">The DNS response that was sent.</param>
-        Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response);
-    }
-
-    /// <summary>
-    /// Allows a DNS App to receive extended query log metadata.
-    /// </summary>
-    public interface IDnsQueryLoggerEx : IDnsQueryLogger
-    {
-        /// <summary>
-        /// Allows a DNS App to log incoming DNS requests and responses, including metadata that may not be present in the wire response.
-        /// </summary>
-        /// <param name="timestamp">The time stamp of the log entry.</param>
-        /// <param name="request">The incoming DNS request that was received.</param>
-        /// <param name="remoteEP">The end point (IP address and port) of the client making the request.</param>
-        /// <param name="protocol">The protocol using which the request was received.</param>
-        /// <param name="response">The DNS response that was sent.</param>
-        /// <param name="metadata">Optional metadata for logging.</param>
-        Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata);
+        /// <param name="metadata">
+        /// Optional out-of-band metadata attached by the component that produced <paramref name="response"/>
+        /// (e.g. blocking zone, block-list zone, or a DNS App plug-in).
+        /// May be <see langword="null"/> for non-blocked or non-enriched responses.
+        /// </param>
+        Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata = null);
     }
 }

--- a/DnsServerCore.ApplicationCommon/IDnsQueryLogger.cs
+++ b/DnsServerCore.ApplicationCommon/IDnsQueryLogger.cs
@@ -57,41 +57,40 @@ namespace DnsServerCore.ApplicationCommon
         public IReadOnlyDictionary<string, string>? AdditionalData { get; init; }
     }
 
-    public sealed class DnsServerResponseMetadata
+    /// <summary>
+    /// Carrier that may be stored in <see cref="TechnitiumLibrary.Net.Dns.DnsDatagram.Tag"/> by the
+    /// DNS server core to provide structured response details for logging.
+    /// During the current transition, consumers must handle both a raw
+    /// <see cref="DnsServerResponseType"/> value and a <see cref="DnsResponseTag"/> instance in
+    /// <see cref="TechnitiumLibrary.Net.Dns.DnsDatagram.Tag"/>. When present, this carrier allows
+    /// blocking apps to attach <see cref="DnsQueryLogMetadata"/> that survives through to
+    /// <see cref="IDnsQueryLogger.InsertLogAsync"/>. Use <see cref="GetResponseType"/> to decode the
+    /// tag safely regardless of which shape is present.
+    /// </summary>
+    public sealed class DnsResponseTag
     {
-        public DnsServerResponseMetadata(DnsServerResponseType responseType, DnsQueryLogMetadata? logMetadata = null)
+        /// <summary>The categorised response type set by the DNS server core.</summary>
+        public DnsServerResponseType ResponseType { get; init; }
+
+        /// <summary>
+        /// Optional metadata populated by a blocking app; <c>null</c> for non-blocking responses.
+        /// </summary>
+        public DnsQueryLogMetadata? Metadata { get; init; }
+
+        /// <summary>
+        /// Decodes the response type from a <see cref="TechnitiumLibrary.Net.Dns.DnsDatagram.Tag"/>
+        /// value, handling both the new <see cref="DnsResponseTag"/> carrier and the legacy boxed
+        /// <see cref="DnsServerResponseType"/> enum value that the core still emits on some code paths.
+        /// Falls back to <see cref="DnsServerResponseType.Recursive"/> when the tag is absent or of
+        /// an unrecognised type.
+        /// </summary>
+        /// <param name="tag">The value of <see cref="TechnitiumLibrary.Net.Dns.DnsDatagram.Tag"/>.</param>
+        public static DnsServerResponseType GetResponseType(object? tag) => tag switch
         {
-            ResponseType = responseType;
-            LogMetadata = logMetadata;
-        }
-
-        public DnsServerResponseType ResponseType { get; }
-        public DnsQueryLogMetadata? LogMetadata { get; }
-    }
-
-    public static class DnsServerResponseTag
-    {
-        public static DnsServerResponseType GetResponseType(object? tag)
-        {
-            if (tag is null)
-                return DnsServerResponseType.Recursive;
-
-            if (tag is DnsServerResponseType responseType)
-                return responseType;
-
-            if (tag is DnsServerResponseMetadata responseMetadata)
-                return responseMetadata.ResponseType;
-
-            return DnsServerResponseType.Recursive;
-        }
-
-        public static DnsQueryLogMetadata? GetLogMetadata(object? tag)
-        {
-            if (tag is DnsServerResponseMetadata responseMetadata)
-                return responseMetadata.LogMetadata;
-
-            return null;
-        }
+            DnsResponseTag dnsResponseTag => dnsResponseTag.ResponseType,
+            DnsServerResponseType dnsServerResponseType => dnsServerResponseType,
+            _ => DnsServerResponseType.Recursive
+        };
     }
 
     public enum DnsServerResponseType : byte

--- a/DnsServerCore.ApplicationCommon/IDnsQueryLogger.cs
+++ b/DnsServerCore.ApplicationCommon/IDnsQueryLogger.cs
@@ -18,6 +18,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using TechnitiumLibrary.Net.Dns;
@@ -26,15 +28,55 @@ namespace DnsServerCore.ApplicationCommon
 {
     public sealed class DnsQueryLogMetadata
     {
-        public DnsQueryLogMetadata(string? blockingReport = null)
+        public DnsQueryLogMetadata(IReadOnlyDictionary<string, string>? values = null)
         {
-            BlockingReport = blockingReport;
+            Values = values is null ? new Dictionary<string, string>(0) : new Dictionary<string, string>(values, StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
-        /// The blocking metadata report (example: <c>source=blocked-zone; domain=example.com</c>).
+        /// Structured metadata key/value pairs (example keys: <c>source</c>, <c>domain</c>, <c>blockListUrl</c>).
         /// </summary>
-        public string? BlockingReport { get; }
+        public IReadOnlyDictionary<string, string> Values { get; }
+
+        public string ToReportString()
+        {
+            if (Values.Count < 1)
+                return string.Empty;
+
+            return string.Join("; ", Values.Select(kv => kv.Key + "=" + kv.Value));
+        }
+
+        public static DnsQueryLogMetadata? ParseReportString(string? report)
+        {
+            if (string.IsNullOrWhiteSpace(report))
+                return null;
+
+            string[] parts = report.Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 1)
+                return null;
+
+            Dictionary<string, string> values = new Dictionary<string, string>(parts.Length, StringComparer.OrdinalIgnoreCase);
+
+            foreach (string part in parts)
+            {
+                int separatorIndex = part.IndexOf('=');
+                if ((separatorIndex < 1) || (separatorIndex >= (part.Length - 1)))
+                    continue;
+
+                string key = part[..separatorIndex].Trim();
+                string value = part[(separatorIndex + 1)..].Trim();
+
+                if ((key.Length < 1) || (value.Length < 1))
+                    continue;
+
+                values[key] = value;
+            }
+
+            if (values.Count < 1)
+                return null;
+
+            return new DnsQueryLogMetadata(values);
+        }
     }
 
     public sealed class DnsServerResponseMetadata

--- a/DnsServerCore.ApplicationCommon/IDnsQueryLogger.cs
+++ b/DnsServerCore.ApplicationCommon/IDnsQueryLogger.cs
@@ -24,6 +24,56 @@ using TechnitiumLibrary.Net.Dns;
 
 namespace DnsServerCore.ApplicationCommon
 {
+    public sealed class DnsQueryLogMetadata
+    {
+        public DnsQueryLogMetadata(string? blockingReport = null)
+        {
+            BlockingReport = blockingReport;
+        }
+
+        /// <summary>
+        /// The blocking metadata report (example: <c>source=blocked-zone; domain=example.com</c>).
+        /// </summary>
+        public string? BlockingReport { get; }
+    }
+
+    public sealed class DnsServerResponseMetadata
+    {
+        public DnsServerResponseMetadata(DnsServerResponseType responseType, DnsQueryLogMetadata? logMetadata = null)
+        {
+            ResponseType = responseType;
+            LogMetadata = logMetadata;
+        }
+
+        public DnsServerResponseType ResponseType { get; }
+        public DnsQueryLogMetadata? LogMetadata { get; }
+    }
+
+    public static class DnsServerResponseTag
+    {
+        public static DnsServerResponseType GetResponseType(object? tag)
+        {
+            if (tag is null)
+                return DnsServerResponseType.Recursive;
+
+            if (tag is DnsServerResponseType responseType)
+                return responseType;
+
+            if (tag is DnsServerResponseMetadata responseMetadata)
+                return responseMetadata.ResponseType;
+
+            return DnsServerResponseType.Recursive;
+        }
+
+        public static DnsQueryLogMetadata? GetLogMetadata(object? tag)
+        {
+            if (tag is DnsServerResponseMetadata responseMetadata)
+                return responseMetadata.LogMetadata;
+
+            return null;
+        }
+    }
+
     public enum DnsServerResponseType : byte
     {
         Authoritative = 1,
@@ -49,5 +99,22 @@ namespace DnsServerCore.ApplicationCommon
         /// <param name="protocol">The protocol using which the request was received.</param>
         /// <param name="response">The DNS response that was sent.</param>
         Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response);
+    }
+
+    /// <summary>
+    /// Allows a DNS App to receive extended query log metadata.
+    /// </summary>
+    public interface IDnsQueryLoggerEx : IDnsQueryLogger
+    {
+        /// <summary>
+        /// Allows a DNS App to log incoming DNS requests and responses, including metadata that may not be present in the wire response.
+        /// </summary>
+        /// <param name="timestamp">The time stamp of the log entry.</param>
+        /// <param name="request">The incoming DNS request that was received.</param>
+        /// <param name="remoteEP">The end point (IP address and port) of the client making the request.</param>
+        /// <param name="protocol">The protocol using which the request was received.</param>
+        /// <param name="response">The DNS response that was sent.</param>
+        /// <param name="metadata">Optional metadata for logging.</param>
+        Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata);
     }
 }

--- a/DnsServerCore/Dns/DnsServer.cs
+++ b/DnsServerCore/Dns/DnsServer.cs
@@ -2375,7 +2375,7 @@ namespace DnsServerCore.Dns
                 {
                     _log.Write(remoteEP, protocol, "DNS Server received a request that failed TSIG signature verification (RCODE: " + errorResponse.RCODE + "; TSIG Error: " + errorResponse.TsigError + ")");
 
-                    errorResponse.Tag = DnsServerResponseType.Authoritative;
+                    errorResponse.Tag = new DnsResponseTag { ResponseType = DnsServerResponseType.Authoritative };
                     return errorResponse;
                 }
 
@@ -3434,7 +3434,7 @@ namespace DnsServerCore.Dns
             {
                 if ((authResponse.RCODE != DnsResponseCode.NoError) || (authResponse.Answer.Count > 0) || (authResponse.Authority.Count == 0) || authResponse.IsFirstAuthoritySOA())
                 {
-                    authResponse.Tag = DnsServerResponseType.Authoritative;
+                    authResponse.Tag = new DnsResponseTag { ResponseType = DnsServerResponseType.Authoritative };
                     return authResponse;
                 }
             }
@@ -3456,7 +3456,7 @@ namespace DnsServerCore.Dns
                             if ((appResponse.RCODE != DnsResponseCode.NoError) || (appResponse.Answer.Count > 0) || (appResponse.Authority.Count == 0) || appResponse.IsFirstAuthoritySOA())
                             {
                                 if (appResponse.Tag is null)
-                                    appResponse.Tag = DnsServerResponseType.Authoritative;
+                                    appResponse.Tag = new DnsResponseTag { ResponseType = DnsServerResponseType.Authoritative };
 
                                 return appResponse;
                             }
@@ -3554,7 +3554,7 @@ namespace DnsServerCore.Dns
                     else
                     {
                         if (appResponse.AuthoritativeAnswer)
-                            appResponse.Tag = DnsServerResponseType.Authoritative;
+                            appResponse.Tag = new DnsResponseTag { ResponseType = DnsServerResponseType.Authoritative };
 
                         return appResponse; //return app response
                     }
@@ -4026,7 +4026,19 @@ namespace DnsServerCore.Dns
                         if ((firstAuthority is not null) && (firstAuthority.Type == DnsResourceRecordType.SOA))
                             blockedDomain = firstAuthority.Name;
 
-                        response.Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, new DnsQueryLogMetadata { Source = "block-list-zone", Reason = blockedDomain });
+                        response.Tag = new DnsResponseTag
+                        {
+                            ResponseType = DnsServerResponseType.Blocked,
+                            Metadata = new DnsQueryLogMetadata
+                            {
+                                Source = "DnsServer",
+                                Reason = "block-list-zone",
+                                AdditionalData = new Dictionary<string, string>
+                                {
+                                    ["domain"] = blockedDomain
+                                }
+                            }
+                        };
                         return response;
                     }
 
@@ -4050,18 +4062,16 @@ namespace DnsServerCore.Dns
                     {
                         //return meta data
                         string blockedDomain = GetBlockedDomain();
-                        DnsQueryLogMetadata logMetadata = new DnsQueryLogMetadata { Source = "blocked-zone", Reason = blockedDomain };
                         string blockingReport = "source=blocked-zone; domain=" + blockedDomain;
 
                         IReadOnlyList<DnsResourceRecord> answer = [new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, _blockingAnswerTtl, new DnsTXTRecordData(blockingReport))];
 
-                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) };
+                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer) { Tag = new DnsResponseTag { ResponseType = DnsServerResponseType.Blocked, Metadata = new DnsQueryLogMetadata { Source = "DnsServer", Reason = "blocked-zone", AdditionalData = new Dictionary<string, string> { ["domain"] = blockedDomain } } } };
                     }
                     else
                     {
                         string blockedDomain = GetBlockedDomain();
                         EDnsOption[] options = null;
-                        DnsQueryLogMetadata logMetadata = new DnsQueryLogMetadata { Source = "blocked-zone", Reason = blockedDomain };
 
                         if (_allowTxtBlockingReport && (request.EDNS is not null))
                         {
@@ -4088,7 +4098,7 @@ namespace DnsServerCore.Dns
                                 if (parentDomain is null)
                                     parentDomain = string.Empty;
 
-                                return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NxDomain, request.Question, null, [new DnsResourceRecord(parentDomain, DnsResourceRecordType.SOA, question.Class, _blockingAnswerTtl, _blockedZoneManager.DnsSOARecord)], null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) };
+                                return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NxDomain, request.Question, null, [new DnsResourceRecord(parentDomain, DnsResourceRecordType.SOA, question.Class, _blockingAnswerTtl, _blockedZoneManager.DnsSOARecord)], null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = new DnsResponseTag { ResponseType = DnsServerResponseType.Blocked, Metadata = new DnsQueryLogMetadata { Source = "DnsServer", Reason = "blocked-zone", AdditionalData = new Dictionary<string, string> { ["domain"] = blockedDomain } } } };
 
                             default:
                                 throw new InvalidOperationException();
@@ -4145,7 +4155,7 @@ namespace DnsServerCore.Dns
                                 break;
                         }
 
-                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer, authority, null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) };
+                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer, authority, null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = new DnsResponseTag { ResponseType = DnsServerResponseType.Blocked, Metadata = new DnsQueryLogMetadata { Source = "DnsServer", Reason = "blocked-zone", AdditionalData = new Dictionary<string, string> { ["domain"] = blockedDomain } } } };
                     }
                 }
             }
@@ -4157,8 +4167,7 @@ namespace DnsServerCore.Dns
                     DnsDatagram appBlockedResponse = await blockingHandler.ProcessRequestAsync(request, remoteEP);
                     if (appBlockedResponse is not null)
                     {
-                        if (appBlockedResponse.Tag is null)
-                            appBlockedResponse.Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked);
+                        appBlockedResponse.Tag = new DnsResponseTag { ResponseType = DnsServerResponseType.Blocked, Metadata = (appBlockedResponse.Tag as DnsResponseTag)?.Metadata };
 
                         return appBlockedResponse;
                     }

--- a/DnsServerCore/Dns/DnsServer.cs
+++ b/DnsServerCore/Dns/DnsServer.cs
@@ -4026,7 +4026,7 @@ namespace DnsServerCore.Dns
                         if ((firstAuthority is not null) && (firstAuthority.Type == DnsResourceRecordType.SOA))
                             blockedDomain = firstAuthority.Name;
 
-                        response.Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, new DnsQueryLogMetadata(new Dictionary<string, string>(2, StringComparer.OrdinalIgnoreCase) { ["source"] = "block-list-zone", ["domain"] = blockedDomain }));
+                        response.Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, new DnsQueryLogMetadata { Source = "block-list-zone", Reason = blockedDomain });
                         return response;
                     }
 
@@ -4050,9 +4050,10 @@ namespace DnsServerCore.Dns
                     {
                         //return meta data
                         string blockedDomain = GetBlockedDomain();
-                        DnsQueryLogMetadata logMetadata = new DnsQueryLogMetadata(new Dictionary<string, string>(2, StringComparer.OrdinalIgnoreCase) { ["source"] = "blocked-zone", ["domain"] = blockedDomain });
+                        DnsQueryLogMetadata logMetadata = new DnsQueryLogMetadata { Source = "blocked-zone", Reason = blockedDomain };
+                        string blockingReport = "source=blocked-zone; domain=" + blockedDomain;
 
-                        IReadOnlyList<DnsResourceRecord> answer = [new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, _blockingAnswerTtl, new DnsTXTRecordData(logMetadata.ToReportString()))];
+                        IReadOnlyList<DnsResourceRecord> answer = [new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, _blockingAnswerTtl, new DnsTXTRecordData(blockingReport))];
 
                         return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) };
                     }
@@ -4060,11 +4061,11 @@ namespace DnsServerCore.Dns
                     {
                         string blockedDomain = GetBlockedDomain();
                         EDnsOption[] options = null;
-                        DnsQueryLogMetadata logMetadata = new DnsQueryLogMetadata(new Dictionary<string, string>(2, StringComparer.OrdinalIgnoreCase) { ["source"] = "blocked-zone", ["domain"] = blockedDomain });
+                        DnsQueryLogMetadata logMetadata = new DnsQueryLogMetadata { Source = "blocked-zone", Reason = blockedDomain };
 
                         if (_allowTxtBlockingReport && (request.EDNS is not null))
                         {
-                            options = [new EDnsOption(EDnsOptionCode.EXTENDED_DNS_ERROR, new EDnsExtendedDnsErrorOptionData(EDnsExtendedDnsErrorCode.Blocked, logMetadata.ToReportString()))];
+                            options = [new EDnsOption(EDnsOptionCode.EXTENDED_DNS_ERROR, new EDnsExtendedDnsErrorOptionData(EDnsExtendedDnsErrorCode.Blocked, "source=blocked-zone; domain=" + blockedDomain))];
                         }
 
                         IReadOnlyCollection<DnsARecordData> aRecords;

--- a/DnsServerCore/Dns/DnsServer.cs
+++ b/DnsServerCore/Dns/DnsServer.cs
@@ -4259,17 +4259,28 @@ namespace DnsServerCore.Dns
                 }
             }
 
-            DnsServerResponseType responseType = DnsServerResponseTag.GetResponseType(response.Tag);
+            switch (response.Tag)
+            {
+                case DnsResponseTag { ResponseType: DnsServerResponseType.Cached } cachedTag:
+                    if (response.IsBlockedResponse())
+                        response.Tag = new DnsResponseTag { ResponseType = DnsServerResponseType.UpstreamBlockedCached, Metadata = cachedTag.Metadata };
+                    break;
 
-            if (response.Tag is null)
-            {
-                if (response.IsBlockedResponse())
-                    response.Tag = DnsServerResponseType.UpstreamBlocked;
-            }
-            else if (responseType == DnsServerResponseType.Cached)
-            {
-                if (response.IsBlockedResponse())
-                    response.Tag = DnsServerResponseType.UpstreamBlockedCached;
+                case DnsServerResponseType.Cached:
+                    if (response.IsBlockedResponse())
+                        response.Tag = new DnsResponseTag { ResponseType = DnsServerResponseType.UpstreamBlockedCached };
+                    break;
+
+                case DnsResponseTag _:
+                    break; //already a non-Cached DnsResponseTag; preserve it
+
+                case DnsServerResponseType _:
+                    break; //legacy non-Cached enum tag; preserve it
+
+                default:
+                    if (response.IsBlockedResponse())
+                        response.Tag = new DnsResponseTag { ResponseType = DnsServerResponseType.UpstreamBlocked };
+                    break;
             }
 
             return response;
@@ -5469,7 +5480,7 @@ namespace DnsServerCore.Dns
             {
                 if ((cacheResponse.RCODE != DnsResponseCode.NoError) || (cacheResponse.Answer.Count > 0) || (cacheResponse.Authority.Count == 0) || cacheResponse.IsFirstAuthoritySOA())
                 {
-                    cacheResponse.Tag = DnsServerResponseType.Cached;
+                    cacheResponse.Tag = new DnsResponseTag { ResponseType = DnsServerResponseType.Cached };
 
                     return cacheResponse;
                 }

--- a/DnsServerCore/Dns/DnsServer.cs
+++ b/DnsServerCore/Dns/DnsServer.cs
@@ -4026,7 +4026,7 @@ namespace DnsServerCore.Dns
                         if ((firstAuthority is not null) && (firstAuthority.Type == DnsResourceRecordType.SOA))
                             blockedDomain = firstAuthority.Name;
 
-                        response.Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, new DnsQueryLogMetadata("source=block-list-zone; domain=" + blockedDomain));
+                        response.Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, new DnsQueryLogMetadata(new Dictionary<string, string>(2, StringComparer.OrdinalIgnoreCase) { ["source"] = "block-list-zone", ["domain"] = blockedDomain }));
                         return response;
                     }
 
@@ -4050,9 +4050,9 @@ namespace DnsServerCore.Dns
                     {
                         //return meta data
                         string blockedDomain = GetBlockedDomain();
-                        DnsQueryLogMetadata logMetadata = new DnsQueryLogMetadata("source=blocked-zone; domain=" + blockedDomain);
+                        DnsQueryLogMetadata logMetadata = new DnsQueryLogMetadata(new Dictionary<string, string>(2, StringComparer.OrdinalIgnoreCase) { ["source"] = "blocked-zone", ["domain"] = blockedDomain });
 
-                        IReadOnlyList<DnsResourceRecord> answer = [new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, _blockingAnswerTtl, new DnsTXTRecordData(logMetadata.BlockingReport))];
+                        IReadOnlyList<DnsResourceRecord> answer = [new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, _blockingAnswerTtl, new DnsTXTRecordData(logMetadata.ToReportString()))];
 
                         return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) };
                     }
@@ -4060,11 +4060,11 @@ namespace DnsServerCore.Dns
                     {
                         string blockedDomain = GetBlockedDomain();
                         EDnsOption[] options = null;
-                        DnsQueryLogMetadata logMetadata = new DnsQueryLogMetadata("source=blocked-zone; domain=" + blockedDomain);
+                        DnsQueryLogMetadata logMetadata = new DnsQueryLogMetadata(new Dictionary<string, string>(2, StringComparer.OrdinalIgnoreCase) { ["source"] = "blocked-zone", ["domain"] = blockedDomain });
 
                         if (_allowTxtBlockingReport && (request.EDNS is not null))
                         {
-                            options = [new EDnsOption(EDnsOptionCode.EXTENDED_DNS_ERROR, new EDnsExtendedDnsErrorOptionData(EDnsExtendedDnsErrorCode.Blocked, logMetadata.BlockingReport))];
+                            options = [new EDnsOption(EDnsOptionCode.EXTENDED_DNS_ERROR, new EDnsExtendedDnsErrorOptionData(EDnsExtendedDnsErrorCode.Blocked, logMetadata.ToReportString()))];
                         }
 
                         IReadOnlyCollection<DnsARecordData> aRecords;

--- a/DnsServerCore/Dns/DnsServer.cs
+++ b/DnsServerCore/Dns/DnsServer.cs
@@ -4021,7 +4021,12 @@ namespace DnsServerCore.Dns
                     if (response is not null)
                     {
                         //domain is blocked in block list zone
-                        response.Tag = DnsServerResponseType.Blocked;
+                        string blockedDomain = request.Question[0].Name;
+                        DnsResourceRecord firstAuthority = response.FindFirstAuthorityRecord();
+                        if ((firstAuthority is not null) && (firstAuthority.Type == DnsResourceRecordType.SOA))
+                            blockedDomain = firstAuthority.Name;
+
+                        response.Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, new DnsQueryLogMetadata("source=block-list-zone; domain=" + blockedDomain));
                         return response;
                     }
 
@@ -4045,20 +4050,21 @@ namespace DnsServerCore.Dns
                     {
                         //return meta data
                         string blockedDomain = GetBlockedDomain();
+                        DnsQueryLogMetadata logMetadata = new DnsQueryLogMetadata("source=blocked-zone; domain=" + blockedDomain);
 
-                        IReadOnlyList<DnsResourceRecord> answer = [new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, _blockingAnswerTtl, new DnsTXTRecordData("source=blocked-zone; domain=" + blockedDomain))];
+                        IReadOnlyList<DnsResourceRecord> answer = [new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, _blockingAnswerTtl, new DnsTXTRecordData(logMetadata.BlockingReport))];
 
-                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer) { Tag = DnsServerResponseType.Blocked };
+                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) };
                     }
                     else
                     {
-                        string blockedDomain = null;
+                        string blockedDomain = GetBlockedDomain();
                         EDnsOption[] options = null;
+                        DnsQueryLogMetadata logMetadata = new DnsQueryLogMetadata("source=blocked-zone; domain=" + blockedDomain);
 
                         if (_allowTxtBlockingReport && (request.EDNS is not null))
                         {
-                            blockedDomain = GetBlockedDomain();
-                            options = [new EDnsOption(EDnsOptionCode.EXTENDED_DNS_ERROR, new EDnsExtendedDnsErrorOptionData(EDnsExtendedDnsErrorCode.Blocked, "source=blocked-zone; domain=" + blockedDomain))];
+                            options = [new EDnsOption(EDnsOptionCode.EXTENDED_DNS_ERROR, new EDnsExtendedDnsErrorOptionData(EDnsExtendedDnsErrorCode.Blocked, logMetadata.BlockingReport))];
                         }
 
                         IReadOnlyCollection<DnsARecordData> aRecords;
@@ -4077,14 +4083,11 @@ namespace DnsServerCore.Dns
                                 break;
 
                             case DnsServerBlockingType.NxDomain:
-                                if (blockedDomain is null)
-                                    blockedDomain = GetBlockedDomain();
-
                                 string parentDomain = AuthZoneManager.GetParentZone(blockedDomain);
                                 if (parentDomain is null)
                                     parentDomain = string.Empty;
 
-                                return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NxDomain, request.Question, null, [new DnsResourceRecord(parentDomain, DnsResourceRecordType.SOA, question.Class, _blockingAnswerTtl, _blockedZoneManager.DnsSOARecord)], null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = DnsServerResponseType.Blocked };
+                                return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NxDomain, request.Question, null, [new DnsResourceRecord(parentDomain, DnsResourceRecordType.SOA, question.Class, _blockingAnswerTtl, _blockedZoneManager.DnsSOARecord)], null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) };
 
                             default:
                                 throw new InvalidOperationException();
@@ -4141,7 +4144,7 @@ namespace DnsServerCore.Dns
                                 break;
                         }
 
-                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer, authority, null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = DnsServerResponseType.Blocked };
+                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer, authority, null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) };
                     }
                 }
             }
@@ -4154,7 +4157,7 @@ namespace DnsServerCore.Dns
                     if (appBlockedResponse is not null)
                     {
                         if (appBlockedResponse.Tag is null)
-                            appBlockedResponse.Tag = DnsServerResponseType.Blocked;
+                            appBlockedResponse.Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked);
 
                         return appBlockedResponse;
                     }
@@ -4246,12 +4249,14 @@ namespace DnsServerCore.Dns
                 }
             }
 
+            DnsServerResponseType responseType = DnsServerResponseTag.GetResponseType(response.Tag);
+
             if (response.Tag is null)
             {
                 if (response.IsBlockedResponse())
                     response.Tag = DnsServerResponseType.UpstreamBlocked;
             }
-            else if ((DnsServerResponseType)response.Tag == DnsServerResponseType.Cached)
+            else if (responseType == DnsServerResponseType.Cached)
             {
                 if (response.IsBlockedResponse())
                     response.Tag = DnsServerResponseType.UpstreamBlockedCached;

--- a/DnsServerCore/Dns/StatsManager.cs
+++ b/DnsServerCore/Dns/StatsManager.cs
@@ -32,6 +32,7 @@ using System.Threading.Channels;
 using TechnitiumLibrary.IO;
 using TechnitiumLibrary.Net;
 using TechnitiumLibrary.Net.Dns;
+using TechnitiumLibrary.Net.Dns.EDnsOptions;
 using TechnitiumLibrary.Net.Dns.ResourceRecords;
 
 namespace DnsServerCore.Dns
@@ -141,10 +142,8 @@ namespace DnsServerCore.Dns
 
                             if (item._response is null)
                                 responseType = DnsServerResponseType.Dropped;
-                            else if (item._response.Tag is null)
-                                responseType = DnsServerResponseType.Recursive;
                             else
-                                responseType = (DnsServerResponseType)item._response.Tag;
+                                responseType = DnsServerResponseTag.GetResponseType(item._response.Tag);
 
                             statCounter.Update(query, item._response is null ? DnsResponseCode.NoError : item._response.RCODE, responseType, item._remoteEP.Address, item._protocol, item._rateLimited);
                         }
@@ -156,7 +155,12 @@ namespace DnsServerCore.Dns
                         {
                             try
                             {
-                                _ = logger.InsertLogAsync(item._timestamp, item._request, item._remoteEP, item._protocol, item._response);
+                                DnsQueryLogMetadata? logMetadata = DnsServerResponseTag.GetLogMetadata(item._response.Tag) ?? GetInlineLogMetadata(item._response);
+
+                                if (logger is IDnsQueryLoggerEx loggerEx)
+                                    _ = loggerEx.InsertLogAsync(item._timestamp, item._request, item._remoteEP, item._protocol, item._response, logMetadata);
+                                else
+                                    _ = logger.InsertLogAsync(item._timestamp, item._request, item._remoteEP, item._protocol, item._response);
                             }
                             catch (Exception ex)
                             {
@@ -542,6 +546,47 @@ namespace DnsServerCore.Dns
 
             _hourlyStatsCache.Clear();
             _dailyStatsCache.Clear();
+        }
+
+        #endregion
+
+        #region helper methods
+
+        private static DnsQueryLogMetadata? GetInlineLogMetadata(DnsDatagram response)
+        {
+            if (response.Answer.Count > 0)
+            {
+                foreach (DnsResourceRecord answer in response.Answer)
+                {
+                    if (answer.Type == DnsResourceRecordType.TXT)
+                    {
+                        if (answer.RDATA is DnsTXTRecordData txtData)
+                        {
+                            string txtString = txtData.ToString();
+                            if (txtString.Contains("source=", StringComparison.Ordinal))
+                                return new DnsQueryLogMetadata(txtString);
+                        }
+                    }
+                }
+            }
+
+            if (response.EDNS is not null)
+            {
+                foreach (EDnsOption option in response.EDNS.Options)
+                {
+                    if (option.Code != EDnsOptionCode.EXTENDED_DNS_ERROR)
+                        continue;
+
+                    string optionString = option.Data.ToString();
+                    int separatorIndex = optionString.IndexOf(':');
+                    if ((separatorIndex > -1) && (separatorIndex < (optionString.Length - 1)))
+                        return new DnsQueryLogMetadata(optionString[(separatorIndex + 1)..].Trim().TrimEnd(']'));
+
+                    return new DnsQueryLogMetadata(optionString);
+                }
+            }
+
+            return null;
         }
 
         #endregion

--- a/DnsServerCore/Dns/StatsManager.cs
+++ b/DnsServerCore/Dns/StatsManager.cs
@@ -142,7 +142,7 @@ namespace DnsServerCore.Dns
                             if (item._response is null)
                                 responseType = DnsServerResponseType.Dropped;
                             else
-                                responseType = DnsServerResponseTag.GetResponseType(item._response.Tag);
+                                responseType = DnsResponseTag.GetResponseType(item._response.Tag);
 
                             statCounter.Update(query, item._response is null ? DnsResponseCode.NoError : item._response.RCODE, responseType, item._remoteEP.Address, item._protocol, item._rateLimited);
                         }
@@ -150,7 +150,7 @@ namespace DnsServerCore.Dns
                         if ((item._request is null) || (item._response is null))
                             continue; //skip dropped requests for apps to prevent DoS
 
-                        DnsQueryLogMetadata? logMetadata = DnsServerResponseTag.GetLogMetadata(item._response.Tag);
+                        DnsQueryLogMetadata? logMetadata = (item._response.Tag as DnsResponseTag)?.Metadata;
 
                         foreach (IDnsQueryLogger logger in _dnsServer.DnsApplicationManager.DnsQueryLoggers)
                         {

--- a/DnsServerCore/Dns/StatsManager.cs
+++ b/DnsServerCore/Dns/StatsManager.cs
@@ -150,12 +150,12 @@ namespace DnsServerCore.Dns
                         if ((item._request is null) || (item._response is null))
                             continue; //skip dropped requests for apps to prevent DoS
 
+                        DnsQueryLogMetadata? logMetadata = DnsServerResponseTag.GetLogMetadata(item._response.Tag);
+
                         foreach (IDnsQueryLogger logger in _dnsServer.DnsApplicationManager.DnsQueryLoggers)
                         {
                             try
                             {
-                                DnsQueryLogMetadata? logMetadata = DnsServerResponseTag.GetLogMetadata(item._response.Tag);
-
                                 if (logger is IDnsQueryLoggerEx loggerEx)
                                     _ = loggerEx.InsertLogAsync(item._timestamp, item._request, item._remoteEP, item._protocol, item._response, logMetadata);
                                 else

--- a/DnsServerCore/Dns/StatsManager.cs
+++ b/DnsServerCore/Dns/StatsManager.cs
@@ -564,7 +564,7 @@ namespace DnsServerCore.Dns
                         {
                             string txtString = txtData.ToString();
                             if (txtString.Contains("source=", StringComparison.Ordinal))
-                                return new DnsQueryLogMetadata(txtString);
+                                return DnsQueryLogMetadata.ParseReportString(txtString);
                         }
                     }
                 }
@@ -580,9 +580,9 @@ namespace DnsServerCore.Dns
                     string optionString = option.Data.ToString();
                     int separatorIndex = optionString.IndexOf(':');
                     if ((separatorIndex > -1) && (separatorIndex < (optionString.Length - 1)))
-                        return new DnsQueryLogMetadata(optionString[(separatorIndex + 1)..].Trim().TrimEnd(']'));
+                        return DnsQueryLogMetadata.ParseReportString(optionString[(separatorIndex + 1)..].Trim().TrimEnd(']'));
 
-                    return new DnsQueryLogMetadata(optionString);
+                    return DnsQueryLogMetadata.ParseReportString(optionString);
                 }
             }
 

--- a/DnsServerCore/Dns/StatsManager.cs
+++ b/DnsServerCore/Dns/StatsManager.cs
@@ -32,7 +32,6 @@ using System.Threading.Channels;
 using TechnitiumLibrary.IO;
 using TechnitiumLibrary.Net;
 using TechnitiumLibrary.Net.Dns;
-using TechnitiumLibrary.Net.Dns.EDnsOptions;
 using TechnitiumLibrary.Net.Dns.ResourceRecords;
 
 namespace DnsServerCore.Dns
@@ -155,7 +154,7 @@ namespace DnsServerCore.Dns
                         {
                             try
                             {
-                                DnsQueryLogMetadata? logMetadata = DnsServerResponseTag.GetLogMetadata(item._response.Tag) ?? GetInlineLogMetadata(item._response);
+                                DnsQueryLogMetadata? logMetadata = DnsServerResponseTag.GetLogMetadata(item._response.Tag);
 
                                 if (logger is IDnsQueryLoggerEx loggerEx)
                                     _ = loggerEx.InsertLogAsync(item._timestamp, item._request, item._remoteEP, item._protocol, item._response, logMetadata);
@@ -546,47 +545,6 @@ namespace DnsServerCore.Dns
 
             _hourlyStatsCache.Clear();
             _dailyStatsCache.Clear();
-        }
-
-        #endregion
-
-        #region helper methods
-
-        private static DnsQueryLogMetadata? GetInlineLogMetadata(DnsDatagram response)
-        {
-            if (response.Answer.Count > 0)
-            {
-                foreach (DnsResourceRecord answer in response.Answer)
-                {
-                    if (answer.Type == DnsResourceRecordType.TXT)
-                    {
-                        if (answer.RDATA is DnsTXTRecordData txtData)
-                        {
-                            string txtString = txtData.ToString();
-                            if (txtString.Contains("source=", StringComparison.Ordinal))
-                                return DnsQueryLogMetadata.ParseReportString(txtString);
-                        }
-                    }
-                }
-            }
-
-            if (response.EDNS is not null)
-            {
-                foreach (EDnsOption option in response.EDNS.Options)
-                {
-                    if (option.Code != EDnsOptionCode.EXTENDED_DNS_ERROR)
-                        continue;
-
-                    string optionString = option.Data.ToString();
-                    int separatorIndex = optionString.IndexOf(':');
-                    if ((separatorIndex > -1) && (separatorIndex < (optionString.Length - 1)))
-                        return DnsQueryLogMetadata.ParseReportString(optionString[(separatorIndex + 1)..].Trim().TrimEnd(']'));
-
-                    return DnsQueryLogMetadata.ParseReportString(optionString);
-                }
-            }
-
-            return null;
         }
 
         #endregion

--- a/DnsServerCore/Dns/StatsManager.cs
+++ b/DnsServerCore/Dns/StatsManager.cs
@@ -156,10 +156,7 @@ namespace DnsServerCore.Dns
                         {
                             try
                             {
-                                if (logger is IDnsQueryLoggerEx loggerEx)
-                                    _ = loggerEx.InsertLogAsync(item._timestamp, item._request, item._remoteEP, item._protocol, item._response, logMetadata);
-                                else
-                                    _ = logger.InsertLogAsync(item._timestamp, item._request, item._remoteEP, item._protocol, item._response);
+                                _ = logger.InsertLogAsync(item._timestamp, item._request, item._remoteEP, item._protocol, item._response, logMetadata);
                             }
                             catch (Exception ex)
                             {


### PR DESCRIPTION
### Motivation
- Provide logging apps with consistent blocking metadata even when the wire response cannot include EDNS/TXT (e.g., non-TXT query without EDNS) by carrying metadata out-of-band rather than altering DNS datagrams.
- Keep DNS protocol behavior unchanged while allowing blocking apps to optionally supply structured metadata for log consumers.

### Description
- Introduce `DnsQueryLogMetadata` with explicit typed properties (`Source`, `Reason`, `Reference`, `AdditionalData`) and `DnsResponseTag` (unified carrier class replacing the earlier `DnsServerResponseMetadata`/`DnsServerResponseTag` split); `DnsResponseTag.GetResponseType` safely decodes both the new carrier and legacy boxed `DnsServerResponseType` enum values still present on some code paths.
- Extend `IDnsQueryLogger.InsertLogAsync` with an optional `DnsQueryLogMetadata? metadata = null` parameter directly, removing the need for a separate `IDnsQueryLoggerEx` interface. Existing implementations that don't override the parameter continue to compile without changes.
- Update `DnsServer` to attach `DnsResponseTag` (with `DnsQueryLogMetadata`) on **all** tag-assignment sites — Authoritative, Cached, blocked-zone, block-list-zone, app-blocked, UpstreamBlocked, and UpstreamBlockedCached — so no raw enum values remain in flight; blocked-zone and block-list-zone paths populate `Source = "DnsServer"`, `Reason`, and a `"domain"` entry in `AdditionalData`.
- Update `AdvancedBlockingApp` to attach `DnsResponseTag` on all blocked-response return paths, populated with `Source = "AdvancedBlockingApp"`, `Reason = "advanced-blocking-app"`, the block-list URL as `Reference`, and group name plus domain or regex in `AdditionalData`.
- Update `MispConnectorApp` to attach `DnsResponseTag` on all blocked-response return paths, populated with `Source = "MispConnector"`, `Reason = "misp-connector"`, and the blocked domain in `AdditionalData`.
- Update `StatsManager` to extract metadata once per queue item (via `(response.Tag as DnsResponseTag)?.Metadata`) and forward it to all registered `IDnsQueryLogger` implementations in a single unified loop.
- Update `LogExporterApp` to implement `IDnsQueryLogger` and expose `Source`, `Reason`, `Reference`, and `AdditionalData` fields in `LogEntry` (no inline TXT/EDE fallback — the serialised `DnsDatagram` provides full wire detail).
- Update `QueryLogsSqliteApp`, `QueryLogsMySqlApp`, and `QueryLogsSqlServerApp` to accept the new `metadata` parameter; the parameter is not persisted as these apps have no metadata columns in their schemas.

### Testing
- Ran repository-wide symbol/usage searches to validate references to `DnsResponseTag`, `DnsQueryLogMetadata`, and `DnsResponseTag.GetResponseType`.
- Verified code edits with `git` operations and committed changes.
- Attempted to run `dotnet build DnsServer.sln` but `dotnet` is not available in this environment, so full compile/build tests could not be executed.

------
<a href="https://chatgpt.com/codex/tasks/task_e_69d212e923208332bffcb2737cdc0c91">Codex Task</a>