### PR TITLE
Propagate structured block metadata to logs and add extended logger interface

### DIFF
--- a/Apps/LogExporterApp/App.cs
+++ b/Apps/LogExporterApp/App.cs
@@ -31,7 +31,7 @@ using TechnitiumLibrary.Net.Dns;
 
 namespace LogExporter
 {
-    public sealed class App : IDnsApplication, IDnsQueryLogger
+    public sealed class App : IDnsApplication, IDnsQueryLoggerEx
     {
         #region variables
 
@@ -139,10 +139,15 @@ namespace LogExporter
 
         public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response)
         {
+            return InsertLogAsync(timestamp, request, remoteEP, protocol, response, null);
+        }
+
+        public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata)
+        {
             if (_enableLogging)
             {
                 if (_queuedLogs.Count < _config!.MaxQueueSize)
-                    _queuedLogs.Enqueue(new LogEntry(timestamp, remoteEP, protocol, request, response, _config.EnableEdnsLogging));
+                    _queuedLogs.Enqueue(new LogEntry(timestamp, remoteEP, protocol, request, response, _config.EnableEdnsLogging, metadata));
             }
 
             return Task.CompletedTask;

--- a/Apps/LogExporterApp/LogEntry.cs
+++ b/Apps/LogExporterApp/LogEntry.cs
@@ -33,7 +33,7 @@ namespace LogExporter
 {
     public class LogEntry
     {
-        public LogEntry(DateTime timestamp, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram request, DnsDatagram response, bool ednsLogging = false)
+        public LogEntry(DateTime timestamp, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram request, DnsDatagram response, bool ednsLogging = false, DnsQueryLogMetadata? metadata = null)
         {
             // Assign timestamp and ensure it's in UTC
             Timestamp = timestamp.Kind == DateTimeKind.Utc ? timestamp : timestamp.ToUniversalTime();
@@ -41,7 +41,8 @@ namespace LogExporter
             // Extract client information
             ClientIp = remoteEP.Address.ToString();
             Protocol = protocol;
-            ResponseType = response.Tag == null ? DnsServerResponseType.Recursive : (DnsServerResponseType)response.Tag;
+            ResponseType = DnsServerResponseTag.GetResponseType(response.Tag);
+            BlockingMetadata = metadata?.Values;
 
             if ((ResponseType == DnsServerResponseType.Recursive) && (response.Metadata is not null))
                 ResponseRtt = response.Metadata.RoundTripTime;
@@ -84,18 +85,27 @@ namespace LogExporter
 
             foreach (EDnsOption extendedErrorLog in response.EDNS.Options.Where(o => o.Code == EDnsOptionCode.EXTENDED_DNS_ERROR))
             {
-                string[] extractedData = extendedErrorLog.Data.ToString().Replace("[", string.Empty).Replace("]", string.Empty).Split(":", StringSplitOptions.TrimEntries);
+                string[] extractedData = extendedErrorLog.Data.ToString().Replace("[", string.Empty).Replace("]", string.Empty).Split(":", 2, StringSplitOptions.TrimEntries);
+                string? errType = null;
+                string? message = null;
+
+                if (extractedData.Length > 0)
+                    errType = extractedData[0];
+
+                if (extractedData.Length > 1)
+                    message = extractedData[1];
 
                 EDNS.Add(new EDNSLog
                 {
-                    ErrType = extractedData[0],
-                    Message = extractedData[1]
+                    ErrType = errType,
+                    Message = message
                 });
             }
         }
 
         public List<DnsResourceRecord> Answers { get; private set; }
         public string ClientIp { get; private set; }
+        public IReadOnlyDictionary<string, string>? BlockingMetadata { get; private set; }
         public List<EDNSLog> EDNS { get; private set; }
         public DnsTransportProtocol Protocol { get; private set; }
         public DnsQuestion? Question { get; private set; }

--- a/Apps/QueryLogsMySqlApp/App.cs
+++ b/Apps/QueryLogsMySqlApp/App.cs
@@ -248,12 +248,7 @@ namespace QueryLogsMySql
                             paramClientIp.Value = log.RemoteEP.Address.ToString();
                             paramProtocol.Value = (byte)log.Protocol;
 
-                            DnsServerResponseType responseType;
-
-                            if (log.Response.Tag == null)
-                                responseType = DnsServerResponseType.Recursive;
-                            else
-                                responseType = (DnsServerResponseType)log.Response.Tag;
+                            DnsServerResponseType responseType = DnsServerResponseTag.GetResponseType(log.Response.Tag);
 
                             paramResponseType.Value = (byte)responseType;
 

--- a/Apps/QueryLogsSqlServerApp/App.cs
+++ b/Apps/QueryLogsSqlServerApp/App.cs
@@ -249,12 +249,7 @@ namespace QueryLogsSqlServer
                             paramClientIp.Value = log.RemoteEP.Address.ToString();
                             paramProtocol.Value = (byte)log.Protocol;
 
-                            DnsServerResponseType responseType;
-
-                            if (log.Response.Tag == null)
-                                responseType = DnsServerResponseType.Recursive;
-                            else
-                                responseType = (DnsServerResponseType)log.Response.Tag;
+                            DnsServerResponseType responseType = DnsServerResponseTag.GetResponseType(log.Response.Tag);
 
                             paramResponseType.Value = (byte)responseType;
 

--- a/Apps/QueryLogsSqliteApp/App.cs
+++ b/Apps/QueryLogsSqliteApp/App.cs
@@ -245,12 +245,7 @@ namespace QueryLogsSqlite
                                 paramClientIp.Value = log.RemoteEP.Address.ToString();
                                 paramProtocol.Value = (int)log.Protocol;
 
-                                DnsServerResponseType responseType;
-
-                                if (log.Response.Tag == null)
-                                    responseType = DnsServerResponseType.Recursive;
-                                else
-                                    responseType = (DnsServerResponseType)log.Response.Tag;
+                                DnsServerResponseType responseType = DnsServerResponseTag.GetResponseType(log.Response.Tag);
 
                                 paramResponseType.Value = (int)responseType;
 

--- a/DnsServerCore.ApplicationCommon/IDnsQueryLogger.cs
+++ b/DnsServerCore.ApplicationCommon/IDnsQueryLogger.cs
@@ -18,12 +18,104 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using TechnitiumLibrary.Net.Dns;
 
 namespace DnsServerCore.ApplicationCommon
 {
+    public sealed class DnsQueryLogMetadata
+    {
+        public DnsQueryLogMetadata(IReadOnlyDictionary<string, string>? values = null)
+        {
+            Values = values is null ? new Dictionary<string, string>(0) : new Dictionary<string, string>(values, StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Structured metadata key/value pairs (example keys: <c>source</c>, <c>domain</c>, <c>blockListUrl</c>).
+        /// </summary>
+        public IReadOnlyDictionary<string, string> Values { get; }
+
+        public string ToReportString()
+        {
+            if (Values.Count < 1)
+                return string.Empty;
+
+            return string.Join("; ", Values.Select(kv => kv.Key + "=" + kv.Value));
+        }
+
+        public static DnsQueryLogMetadata? ParseReportString(string? report)
+        {
+            if (string.IsNullOrWhiteSpace(report))
+                return null;
+
+            string[] parts = report.Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 1)
+                return null;
+
+            Dictionary<string, string> values = new Dictionary<string, string>(parts.Length, StringComparer.OrdinalIgnoreCase);
+
+            foreach (string part in parts)
+            {
+                int separatorIndex = part.IndexOf('=');
+                if ((separatorIndex < 1) || (separatorIndex >= (part.Length - 1)))
+                    continue;
+
+                string key = part[..separatorIndex].Trim();
+                string value = part[(separatorIndex + 1)..].Trim();
+
+                if ((key.Length < 1) || (value.Length < 1))
+                    continue;
+
+                values[key] = value;
+            }
+
+            if (values.Count < 1)
+                return null;
+
+            return new DnsQueryLogMetadata(values);
+        }
+    }
+
+    public sealed class DnsServerResponseMetadata
+    {
+        public DnsServerResponseMetadata(DnsServerResponseType responseType, DnsQueryLogMetadata? logMetadata = null)
+        {
+            ResponseType = responseType;
+            LogMetadata = logMetadata;
+        }
+
+        public DnsServerResponseType ResponseType { get; }
+        public DnsQueryLogMetadata? LogMetadata { get; }
+    }
+
+    public static class DnsServerResponseTag
+    {
+        public static DnsServerResponseType GetResponseType(object? tag)
+        {
+            if (tag is null)
+                return DnsServerResponseType.Recursive;
+
+            if (tag is DnsServerResponseType responseType)
+                return responseType;
+
+            if (tag is DnsServerResponseMetadata responseMetadata)
+                return responseMetadata.ResponseType;
+
+            return DnsServerResponseType.Recursive;
+        }
+
+        public static DnsQueryLogMetadata? GetLogMetadata(object? tag)
+        {
+            if (tag is DnsServerResponseMetadata responseMetadata)
+                return responseMetadata.LogMetadata;
+
+            return null;
+        }
+    }
+
     public enum DnsServerResponseType : byte
     {
         Authoritative = 1,
@@ -49,5 +141,22 @@ namespace DnsServerCore.ApplicationCommon
         /// <param name="protocol">The protocol using which the request was received.</param>
         /// <param name="response">The DNS response that was sent.</param>
         Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response);
+    }
+
+    /// <summary>
+    /// Allows a DNS App to receive extended query log metadata.
+    /// </summary>
+    public interface IDnsQueryLoggerEx : IDnsQueryLogger
+    {
+        /// <summary>
+        /// Allows a DNS App to log incoming DNS requests and responses, including metadata that may not be present in the wire response.
+        /// </summary>
+        /// <param name="timestamp">The time stamp of the log entry.</param>
+        /// <param name="request">The incoming DNS request that was received.</param>
+        /// <param name="remoteEP">The end point (IP address and port) of the client making the request.</param>
+        /// <param name="protocol">The protocol using which the request was received.</param>
+        /// <param name="response">The DNS response that was sent.</param>
+        /// <param name="metadata">Optional metadata for logging.</param>
+        Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata);
     }
 }

--- a/DnsServerCore/Dns/DnsServer.cs
+++ b/DnsServerCore/Dns/DnsServer.cs
@@ -4009,7 +4009,19 @@ namespace DnsServerCore.Dns
             return false;
         }
 
-        private async Task<DnsDatagram> ProcessBlockedQueryAsync(DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol)
+        sealed class BlockedQueryResult
+        {
+            public BlockedQueryResult(DnsDatagram response, DnsQueryLogMetadata? logMetadata = null)
+            {
+                Response = response;
+                LogMetadata = logMetadata;
+            }
+
+            public DnsDatagram Response { get; }
+            public DnsQueryLogMetadata? LogMetadata { get; }
+        }
+
+        private async Task<BlockedQueryResult> ProcessBlockedQueryAsync(DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol)
         {
             if (_enableBlocking)
             {
@@ -4017,7 +4029,7 @@ namespace DnsServerCore.Dns
                 if (response is null)
                 {
                     //domain not blocked in blocked zone
-                    response = _blockListZoneManager.Query(request); //check in block list zone
+                    response = _blockListZoneManager.Query(request, out DnsQueryLogMetadata blockListLogMetadata); //check in block list zone
                     if (response is not null)
                     {
                         //domain is blocked in block list zone
@@ -4031,7 +4043,7 @@ namespace DnsServerCore.Dns
                             response.Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, new DnsQueryLogMetadata(new Dictionary<string, string>(2, StringComparer.OrdinalIgnoreCase) { ["source"] = "block-list-zone", ["domain"] = blockedDomain }));
                         }
 
-                        return response;
+                        return new BlockedQueryResult(response, blockListLogMetadata ?? DnsServerResponseTag.GetLogMetadata(response.Tag));
                     }
 
                     //domain not blocked in block list zone; continue to check app blocking handlers
@@ -4058,7 +4070,7 @@ namespace DnsServerCore.Dns
 
                         IReadOnlyList<DnsResourceRecord> answer = [new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, _blockingAnswerTtl, new DnsTXTRecordData(logMetadata.ToReportString()))];
 
-                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) };
+                        return new BlockedQueryResult(new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) }, logMetadata);
                     }
                     else
                     {
@@ -4091,7 +4103,7 @@ namespace DnsServerCore.Dns
                                 if (parentDomain is null)
                                     parentDomain = string.Empty;
 
-                                return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NxDomain, request.Question, null, [new DnsResourceRecord(parentDomain, DnsResourceRecordType.SOA, question.Class, _blockingAnswerTtl, _blockedZoneManager.DnsSOARecord)], null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) };
+                                return new BlockedQueryResult(new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NxDomain, request.Question, null, [new DnsResourceRecord(parentDomain, DnsResourceRecordType.SOA, question.Class, _blockingAnswerTtl, _blockedZoneManager.DnsSOARecord)], null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) }, logMetadata);
 
                             default:
                                 throw new InvalidOperationException();
@@ -4148,7 +4160,7 @@ namespace DnsServerCore.Dns
                                 break;
                         }
 
-                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer, authority, null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) };
+                        return new BlockedQueryResult(new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer, authority, null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) }, logMetadata);
                     }
                 }
             }
@@ -4163,7 +4175,7 @@ namespace DnsServerCore.Dns
                         if (appBlockedResponse.Tag is null)
                             appBlockedResponse.Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked);
 
-                        return appBlockedResponse;
+                        return new BlockedQueryResult(appBlockedResponse, DnsServerResponseTag.GetLogMetadata(appBlockedResponse.Tag));
                     }
                 }
                 catch (Exception ex)
@@ -4190,9 +4202,9 @@ namespace DnsServerCore.Dns
                 isAllowed = await IsAllowedAsync(request, remoteEP, protocol);
                 if (!isAllowed)
                 {
-                    DnsDatagram blockedResponse = await ProcessBlockedQueryAsync(request, remoteEP, protocol);
+                    BlockedQueryResult blockedResponse = await ProcessBlockedQueryAsync(request, remoteEP, protocol);
                     if (blockedResponse is not null)
-                        return blockedResponse;
+                        return blockedResponse.Response;
                 }
             }
 
@@ -4233,7 +4245,7 @@ namespace DnsServerCore.Dns
                             break; //CNAME is in allowed zone
 
                         //check blocked zone and block list zone
-                        DnsDatagram blockedResponse = await ProcessBlockedQueryAsync(newRequest, remoteEP, protocol);
+                        BlockedQueryResult blockedResponse = await ProcessBlockedQueryAsync(newRequest, remoteEP, protocol);
                         if (blockedResponse is not null)
                         {
                             //found cname cloaking
@@ -4244,10 +4256,13 @@ namespace DnsServerCore.Dns
                                 answer.Add(response.Answer[j]);
 
                             //copy last response answers
-                            answer.AddRange(blockedResponse.Answer);
+                            answer.AddRange(blockedResponse.Response.Answer);
 
                             //include blocked response additional section to pass on Extended DNS Errors
-                            return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, true, true, false, false, blockedResponse.RCODE, request.Question, answer, blockedResponse.Authority, blockedResponse.Additional) { Tag = blockedResponse.Tag };
+                            return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, true, true, false, false, blockedResponse.Response.RCODE, request.Question, answer, blockedResponse.Response.Authority, blockedResponse.Response.Additional)
+                            {
+                                Tag = blockedResponse.LogMetadata is null ? blockedResponse.Response.Tag : new DnsServerResponseMetadata(DnsServerResponseType.Blocked, blockedResponse.LogMetadata)
+                            };
                         }
                     }
                 }

--- a/DnsServerCore/Dns/DnsServer.cs
+++ b/DnsServerCore/Dns/DnsServer.cs
@@ -4021,7 +4021,16 @@ namespace DnsServerCore.Dns
                     if (response is not null)
                     {
                         //domain is blocked in block list zone
-                        response.Tag = DnsServerResponseType.Blocked;
+                        if (response.Tag is null)
+                        {
+                            string blockedDomain = request.Question[0].Name;
+                            DnsResourceRecord firstAuthority = response.FindFirstAuthorityRecord();
+                            if ((firstAuthority is not null) && (firstAuthority.Type == DnsResourceRecordType.SOA))
+                                blockedDomain = firstAuthority.Name;
+
+                            response.Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, new DnsQueryLogMetadata(new Dictionary<string, string>(2, StringComparer.OrdinalIgnoreCase) { ["source"] = "block-list-zone", ["domain"] = blockedDomain }));
+                        }
+
                         return response;
                     }
 
@@ -4045,20 +4054,21 @@ namespace DnsServerCore.Dns
                     {
                         //return meta data
                         string blockedDomain = GetBlockedDomain();
+                        DnsQueryLogMetadata logMetadata = new DnsQueryLogMetadata(new Dictionary<string, string>(2, StringComparer.OrdinalIgnoreCase) { ["source"] = "blocked-zone", ["domain"] = blockedDomain });
 
-                        IReadOnlyList<DnsResourceRecord> answer = [new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, _blockingAnswerTtl, new DnsTXTRecordData("source=blocked-zone; domain=" + blockedDomain))];
+                        IReadOnlyList<DnsResourceRecord> answer = [new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, _blockingAnswerTtl, new DnsTXTRecordData(logMetadata.ToReportString()))];
 
-                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer) { Tag = DnsServerResponseType.Blocked };
+                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) };
                     }
                     else
                     {
-                        string blockedDomain = null;
+                        string blockedDomain = GetBlockedDomain();
                         EDnsOption[] options = null;
+                        DnsQueryLogMetadata logMetadata = new DnsQueryLogMetadata(new Dictionary<string, string>(2, StringComparer.OrdinalIgnoreCase) { ["source"] = "blocked-zone", ["domain"] = blockedDomain });
 
                         if (_allowTxtBlockingReport && (request.EDNS is not null))
                         {
-                            blockedDomain = GetBlockedDomain();
-                            options = [new EDnsOption(EDnsOptionCode.EXTENDED_DNS_ERROR, new EDnsExtendedDnsErrorOptionData(EDnsExtendedDnsErrorCode.Blocked, "source=blocked-zone; domain=" + blockedDomain))];
+                            options = [new EDnsOption(EDnsOptionCode.EXTENDED_DNS_ERROR, new EDnsExtendedDnsErrorOptionData(EDnsExtendedDnsErrorCode.Blocked, logMetadata.ToReportString()))];
                         }
 
                         IReadOnlyCollection<DnsARecordData> aRecords;
@@ -4077,14 +4087,11 @@ namespace DnsServerCore.Dns
                                 break;
 
                             case DnsServerBlockingType.NxDomain:
-                                if (blockedDomain is null)
-                                    blockedDomain = GetBlockedDomain();
-
                                 string parentDomain = AuthZoneManager.GetParentZone(blockedDomain);
                                 if (parentDomain is null)
                                     parentDomain = string.Empty;
 
-                                return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NxDomain, request.Question, null, [new DnsResourceRecord(parentDomain, DnsResourceRecordType.SOA, question.Class, _blockingAnswerTtl, _blockedZoneManager.DnsSOARecord)], null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = DnsServerResponseType.Blocked };
+                                return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NxDomain, request.Question, null, [new DnsResourceRecord(parentDomain, DnsResourceRecordType.SOA, question.Class, _blockingAnswerTtl, _blockedZoneManager.DnsSOARecord)], null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) };
 
                             default:
                                 throw new InvalidOperationException();
@@ -4141,7 +4148,7 @@ namespace DnsServerCore.Dns
                                 break;
                         }
 
-                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer, authority, null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = DnsServerResponseType.Blocked };
+                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer, authority, null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) };
                     }
                 }
             }
@@ -4154,7 +4161,7 @@ namespace DnsServerCore.Dns
                     if (appBlockedResponse is not null)
                     {
                         if (appBlockedResponse.Tag is null)
-                            appBlockedResponse.Tag = DnsServerResponseType.Blocked;
+                            appBlockedResponse.Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked);
 
                         return appBlockedResponse;
                     }
@@ -4246,12 +4253,14 @@ namespace DnsServerCore.Dns
                 }
             }
 
+            DnsServerResponseType responseType = DnsServerResponseTag.GetResponseType(response.Tag);
+
             if (response.Tag is null)
             {
                 if (response.IsBlockedResponse())
                     response.Tag = DnsServerResponseType.UpstreamBlocked;
             }
-            else if ((DnsServerResponseType)response.Tag == DnsServerResponseType.Cached)
+            else if (responseType == DnsServerResponseType.Cached)
             {
                 if (response.IsBlockedResponse())
                     response.Tag = DnsServerResponseType.UpstreamBlockedCached;

--- a/DnsServerCore/Dns/StatsManager.cs
+++ b/DnsServerCore/Dns/StatsManager.cs
@@ -141,10 +141,8 @@ namespace DnsServerCore.Dns
 
                             if (item._response is null)
                                 responseType = DnsServerResponseType.Dropped;
-                            else if (item._response.Tag is null)
-                                responseType = DnsServerResponseType.Recursive;
                             else
-                                responseType = (DnsServerResponseType)item._response.Tag;
+                                responseType = DnsServerResponseTag.GetResponseType(item._response.Tag);
 
                             statCounter.Update(query, item._response is null ? DnsResponseCode.NoError : item._response.RCODE, responseType, item._remoteEP.Address, item._protocol, item._rateLimited);
                         }
@@ -156,7 +154,12 @@ namespace DnsServerCore.Dns
                         {
                             try
                             {
-                                _ = logger.InsertLogAsync(item._timestamp, item._request, item._remoteEP, item._protocol, item._response);
+                                DnsQueryLogMetadata? logMetadata = DnsServerResponseTag.GetLogMetadata(item._response.Tag);
+
+                                if (logger is IDnsQueryLoggerEx loggerEx)
+                                    _ = loggerEx.InsertLogAsync(item._timestamp, item._request, item._remoteEP, item._protocol, item._response, logMetadata);
+                                else
+                                    _ = logger.InsertLogAsync(item._timestamp, item._request, item._remoteEP, item._protocol, item._response);
                             }
                             catch (Exception ex)
                             {

--- a/DnsServerCore/Dns/ZoneManagers/BlockListZoneManager.cs
+++ b/DnsServerCore/Dns/ZoneManagers/BlockListZoneManager.cs
@@ -840,8 +840,10 @@ namespace DnsServerCore.Dns.ZoneManagers
             return IsZoneAllowed(request.Question[0].Name);
         }
 
-        public DnsDatagram Query(DnsDatagram request)
+        public DnsDatagram Query(DnsDatagram request, out DnsQueryLogMetadata logMetadata)
         {
+            logMetadata = null;
+
             if (_blockListZone.Count < 1)
                 return null;
 
@@ -864,6 +866,7 @@ namespace DnsServerCore.Dns.ZoneManagers
             }
 
             DnsServerResponseMetadata responseMetadata = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, new DnsQueryLogMetadata(metadataValues));
+            logMetadata = responseMetadata.LogMetadata;
 
             //zone is blocked
             if (_dnsServer.AllowTxtBlockingReport && (question.Type == DnsResourceRecordType.TXT))

--- a/DnsServerCore/Dns/ZoneManagers/BlockListZoneManager.cs
+++ b/DnsServerCore/Dns/ZoneManagers/BlockListZoneManager.cs
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 */
 
+using DnsServerCore.ApplicationCommon;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -850,6 +851,20 @@ namespace DnsServerCore.Dns.ZoneManagers
             if (blockLists is null)
                 return null; //zone not blocked
 
+            Dictionary<string, string> metadataValues = new Dictionary<string, string>(4, StringComparer.OrdinalIgnoreCase)
+            {
+                ["source"] = "block-list-zone",
+                ["domain"] = blockedDomain
+            };
+
+            if (blockLists.Count > 0)
+            {
+                metadataValues["blockListUrl"] = blockLists[0].AbsoluteUri;
+                metadataValues["blockListCount"] = blockLists.Count.ToString();
+            }
+
+            DnsServerResponseMetadata responseMetadata = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, new DnsQueryLogMetadata(metadataValues));
+
             //zone is blocked
             if (_dnsServer.AllowTxtBlockingReport && (question.Type == DnsResourceRecordType.TXT))
             {
@@ -859,7 +874,7 @@ namespace DnsServerCore.Dns.ZoneManagers
                 for (int i = 0; i < answer.Length; i++)
                     answer[i] = new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, _dnsServer.BlockingAnswerTtl, new DnsTXTRecordData("source=block-list-zone; blockListUrl=" + blockLists[i].AbsoluteUri + "; domain=" + blockedDomain));
 
-                return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer);
+                return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer) { Tag = responseMetadata };
             }
             else
             {
@@ -893,7 +908,7 @@ namespace DnsServerCore.Dns.ZoneManagers
                         if (parentDomain is null)
                             parentDomain = string.Empty;
 
-                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NxDomain, request.Question, null, [new DnsResourceRecord(parentDomain, DnsResourceRecordType.SOA, question.Class, _dnsServer.BlockingAnswerTtl, _soaRecord)], null, request.EDNS is null ? ushort.MinValue : _dnsServer.UdpPayloadSize, EDnsHeaderFlags.None, options);
+                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NxDomain, request.Question, null, [new DnsResourceRecord(parentDomain, DnsResourceRecordType.SOA, question.Class, _dnsServer.BlockingAnswerTtl, _soaRecord)], null, request.EDNS is null ? ushort.MinValue : _dnsServer.UdpPayloadSize, EDnsHeaderFlags.None, options) { Tag = responseMetadata };
 
                     default:
                         throw new InvalidOperationException();
@@ -959,7 +974,7 @@ namespace DnsServerCore.Dns.ZoneManagers
                         break;
                 }
 
-                return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer, authority, null, request.EDNS is null ? ushort.MinValue : _dnsServer.UdpPayloadSize, EDnsHeaderFlags.None, options);
+                return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer, authority, null, request.EDNS is null ? ushort.MinValue : _dnsServer.UdpPayloadSize, EDnsHeaderFlags.None, options) { Tag = responseMetadata };
             }
         }
 


### PR DESCRIPTION
### Motivation

- Carry structured metadata (source, domain, block list info) with blocked DNS responses so loggers and downstream apps can report richer context.
- Preserve existing logger behavior while allowing apps to opt into receiving additional metadata from the DNS server.

### Description

- Added `DnsQueryLogMetadata`, `DnsServerResponseMetadata`, and `DnsServerResponseTag` helpers to encapsulate structured metadata and to centralize response-tag interpretation.
- Introduced `IDnsQueryLoggerEx` (extends `IDnsQueryLogger`) with an overload of `InsertLogAsync(..., metadata)` and updated `StatsManager` to call the metadata-aware API when a logger implements `IDnsQueryLoggerEx` while keeping backward compatibility for existing loggers.
- Updated blocking/code paths to attach `DnsServerResponseMetadata` tags to blocked or upstream-blocked `DnsDatagram` responses (including `source`, `domain`, and optional `blockListUrl`/`blockListCount`) and adjusted apps (`LogExporter`, `QueryLogs*`) and `LogEntry` to read and serialize this metadata as `BlockingMetadata`.
- Improved EDNS extended error parsing to split only on the first separator and handle missing parts safely, and replaced multiple direct casts of `response.Tag` with the new `DnsServerResponseTag` helpers.

### Testing

- Built the solution with `dotnet build` which completed successfully.
- Ran the automated test suites with `dotnet test` for `DnsServerCore` and application projects and they passed.
- Performed integration checks on the logging/blocking path to validate metadata propagation and serialization which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d212e923208332bffcb2737cdc0c91)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured blocking metadata to DNS responses and propagates it to query logs, with an extended logger interface. Blocked-query paths now return metadata alongside the datagram so it’s preserved through processing and logging.

- **New Features**
  - Helpers: DnsQueryLogMetadata, DnsServerResponseMetadata, DnsServerResponseTag.
  - New IDnsQueryLoggerEx with InsertLogAsync(..., metadata); StatsManager passes metadata when available, otherwise falls back.
  - Blocked-zone and block-list-zone tag responses with metadata (source, domain; optional blockListUrl/count) and emit TXT/EDE via ToReportString().
  - DnsServer.ProcessBlockedQueryAsync returns both response and metadata; metadata is preserved when merging responses (e.g., CNAME cloaking).
  - LogExporter implements IDnsQueryLoggerEx; LogEntry exposes BlockingMetadata.

- **Bug Fixes**
  - Safer EDNS Extended DNS Error parsing: split on first “:” and handle missing parts.
  - Replace direct response.Tag casts with DnsServerResponseTag.GetResponseType to avoid invalid casts across apps.

<sup>Written for commit 42318ade2e67e8c49395b72d6570fe574a68c72e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

