### PR TITLE
Propagate structured blocking metadata to loggers and persist in query logs

### DIFF
--- a/Apps/AdvancedBlockingApp/App.cs
+++ b/Apps/AdvancedBlockingApp/App.cs
@@ -605,6 +605,28 @@ namespace AdvancedBlocking
                 return blockingReport;
             }
 
+            DnsQueryLogMetadata GetLogMetadata()
+            {
+                Dictionary<string, string> values = new Dictionary<string, string>(6, StringComparer.OrdinalIgnoreCase)
+                {
+                    ["source"] = "advanced-blocking-app",
+                    ["group"] = group.Name
+                };
+
+                if (blockListUrl?.Uri is not null)
+                    values["blockListUrl"] = blockListUrl.Uri.AbsoluteUri;
+
+                if (blockedRegex is null)
+                    values["domain"] = blockedDomain ?? question.Name;
+                else
+                    values["regex"] = blockedRegex;
+
+                return new DnsQueryLogMetadata(values);
+            }
+
+            DnsQueryLogMetadata logMetadata = GetLogMetadata();
+            DnsServerResponseMetadata responseMetadata = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata);
+
             if (group.AllowTxtBlockingReport && (question.Type == DnsResourceRecordType.TXT))
             {
                 //return meta data
@@ -612,7 +634,7 @@ namespace AdvancedBlocking
 
                 DnsResourceRecord[] answer = [new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, _blockingAnswerTtl, new DnsTXTRecordData(blockingReport))];
 
-                return Task.FromResult<DnsDatagram?>(new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer));
+                return Task.FromResult<DnsDatagram?>(new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer) { Tag = responseMetadata });
             }
             else
             {
@@ -697,7 +719,7 @@ namespace AdvancedBlocking
                     }
                 }
 
-                return Task.FromResult<DnsDatagram?>(new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, rcode, request.Question, answer, authority, null, request.EDNS is null ? ushort.MinValue : _dnsServer!.UdpPayloadSize, EDnsHeaderFlags.None, options));
+                return Task.FromResult<DnsDatagram?>(new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, rcode, request.Question, answer, authority, null, request.EDNS is null ? ushort.MinValue : _dnsServer!.UdpPayloadSize, EDnsHeaderFlags.None, options) { Tag = responseMetadata });
             }
         }
 

--- a/Apps/LogExporterApp/App.cs
+++ b/Apps/LogExporterApp/App.cs
@@ -31,7 +31,7 @@ using TechnitiumLibrary.Net.Dns;
 
 namespace LogExporter
 {
-    public sealed class App : IDnsApplication, IDnsQueryLogger
+    public sealed class App : IDnsApplication, IDnsQueryLoggerEx
     {
         #region variables
 
@@ -139,10 +139,15 @@ namespace LogExporter
 
         public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response)
         {
+            return InsertLogAsync(timestamp, request, remoteEP, protocol, response, null);
+        }
+
+        public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata)
+        {
             if (_enableLogging)
             {
                 if (_queuedLogs.Count < _config!.MaxQueueSize)
-                    _queuedLogs.Enqueue(new LogEntry(timestamp, remoteEP, protocol, request, response, _config.EnableEdnsLogging));
+                    _queuedLogs.Enqueue(new LogEntry(timestamp, remoteEP, protocol, request, response, _config.EnableEdnsLogging, metadata));
             }
 
             return Task.CompletedTask;

--- a/Apps/LogExporterApp/LogEntry.cs
+++ b/Apps/LogExporterApp/LogEntry.cs
@@ -42,7 +42,8 @@ namespace LogExporter
             ClientIp = remoteEP.Address.ToString();
             Protocol = protocol;
             ResponseType = DnsServerResponseTag.GetResponseType(response.Tag);
-            BlockingMetadata = metadata?.Values;
+            DnsQueryLogMetadata? logMetadata = metadata ?? DnsServerResponseTag.GetLogMetadata(response.Tag);
+            BlockingMetadata = logMetadata?.Values;
 
             if ((ResponseType == DnsServerResponseType.Recursive) && (response.Metadata is not null))
                 ResponseRtt = response.Metadata.RoundTripTime;

--- a/Apps/LogExporterApp/LogEntry.cs
+++ b/Apps/LogExporterApp/LogEntry.cs
@@ -33,7 +33,7 @@ namespace LogExporter
 {
     public class LogEntry
     {
-        public LogEntry(DateTime timestamp, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram request, DnsDatagram response, bool ednsLogging = false)
+        public LogEntry(DateTime timestamp, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram request, DnsDatagram response, bool ednsLogging = false, DnsQueryLogMetadata? metadata = null)
         {
             // Assign timestamp and ensure it's in UTC
             Timestamp = timestamp.Kind == DateTimeKind.Utc ? timestamp : timestamp.ToUniversalTime();
@@ -41,7 +41,8 @@ namespace LogExporter
             // Extract client information
             ClientIp = remoteEP.Address.ToString();
             Protocol = protocol;
-            ResponseType = response.Tag == null ? DnsServerResponseType.Recursive : (DnsServerResponseType)response.Tag;
+            ResponseType = DnsServerResponseTag.GetResponseType(response.Tag);
+            BlockingMetadata = metadata?.Values;
 
             if ((ResponseType == DnsServerResponseType.Recursive) && (response.Metadata is not null))
                 ResponseRtt = response.Metadata.RoundTripTime;
@@ -84,18 +85,27 @@ namespace LogExporter
 
             foreach (EDnsOption extendedErrorLog in response.EDNS.Options.Where(o => o.Code == EDnsOptionCode.EXTENDED_DNS_ERROR))
             {
-                string[] extractedData = extendedErrorLog.Data.ToString().Replace("[", string.Empty).Replace("]", string.Empty).Split(":", StringSplitOptions.TrimEntries);
+                string[] extractedData = extendedErrorLog.Data.ToString().Replace("[", string.Empty).Replace("]", string.Empty).Split(":", 2, StringSplitOptions.TrimEntries);
+                string? errType = null;
+                string? message = null;
+
+                if (extractedData.Length > 0)
+                    errType = extractedData[0];
+
+                if (extractedData.Length > 1)
+                    message = extractedData[1];
 
                 EDNS.Add(new EDNSLog
                 {
-                    ErrType = extractedData[0],
-                    Message = extractedData[1]
+                    ErrType = errType,
+                    Message = message
                 });
             }
         }
 
         public List<DnsResourceRecord> Answers { get; private set; }
         public string ClientIp { get; private set; }
+        public IReadOnlyDictionary<string, string>? BlockingMetadata { get; private set; }
         public List<EDNSLog> EDNS { get; private set; }
         public DnsTransportProtocol Protocol { get; private set; }
         public DnsQuestion? Question { get; private set; }

--- a/Apps/LogExporterApp/Strategy/SyslogExportStrategy.cs
+++ b/Apps/LogExporterApp/Strategy/SyslogExportStrategy.cs
@@ -163,6 +163,15 @@ namespace LogExporter.Strategy
                 }
             }
 
+            // Add blocking metadata
+            if ((log.BlockingMetadata is not null) && (log.BlockingMetadata.Count > 0))
+            {
+                foreach (KeyValuePair<string, string> item in log.BlockingMetadata)
+                    properties.Add(new LogEventProperty("blocking_" + item.Key, new ScalarValue(item.Value)));
+
+                properties.Add(new LogEventProperty("blockingMetadataSummary", new ScalarValue(string.Join(", ", log.BlockingMetadata.Select(kv => kv.Key + "=" + kv.Value)))));
+            }
+
             // Define the message template to match the original summary format
             const string templateText = "{questionsSummary}; RCODE: {rCode}; ANSWER: [{answersSummary}]";
 

--- a/Apps/MispConnectorApp/App.cs
+++ b/Apps/MispConnectorApp/App.cs
@@ -150,16 +150,22 @@ namespace MispConnector
             }
 
             string blockingReport = $"source=misp-connector;domain={blockedDomain}";
+            DnsQueryLogMetadata logMetadata = new DnsQueryLogMetadata(new Dictionary<string, string>(2, StringComparer.OrdinalIgnoreCase)
+            {
+                ["source"] = "misp-connector",
+                ["domain"] = blockedDomain
+            });
+            DnsServerResponseMetadata responseMetadata = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata);
 
             EDnsOption[] options = null;
             if (_config.AddExtendedDnsError && request.EDNS is not null)
             {
-                options = new EDnsOption[] { new EDnsOption(EDnsOptionCode.EXTENDED_DNS_ERROR, new EDnsExtendedDnsErrorOptionData(EDnsExtendedDnsErrorCode.Blocked, string.Empty)) };
+                options = new EDnsOption[] { new EDnsOption(EDnsOptionCode.EXTENDED_DNS_ERROR, new EDnsExtendedDnsErrorOptionData(EDnsExtendedDnsErrorCode.Blocked, blockingReport)) };
             }
 
             if (_config.AllowTxtBlockingReport && question.Type == DnsResourceRecordType.TXT)
             {
-                DnsResourceRecord[] answer = new DnsResourceRecord[] { new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, 60, new DnsTXTRecordData(string.Empty)) };
+                DnsResourceRecord[] answer = new DnsResourceRecord[] { new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, 60, new DnsTXTRecordData(blockingReport)) };
                 return Task.FromResult(new DnsDatagram(
                                     ID: request.Identifier,
                                     isResponse: true,
@@ -178,7 +184,7 @@ namespace MispConnector
                                     udpPayloadSize: request.EDNS is null ? ushort.MinValue : _dnsServer.UdpPayloadSize,
                                     ednsFlags: EDnsHeaderFlags.None,
                                     options: options
-                                ));
+                                ) { Tag = responseMetadata });
             }
 
             DnsResourceRecord[] authority = { new DnsResourceRecord(question.Name, DnsResourceRecordType.SOA, question.Class, 60, _soaRecord) };
@@ -200,7 +206,7 @@ namespace MispConnector
                             udpPayloadSize: request.EDNS is null ? ushort.MinValue : _dnsServer.UdpPayloadSize,
                             ednsFlags: EDnsHeaderFlags.None,
                             options: options
-                        ));
+                        ) { Tag = responseMetadata });
         }
 
         #endregion public

--- a/Apps/QueryLogsMySqlApp/App.cs
+++ b/Apps/QueryLogsMySqlApp/App.cs
@@ -34,7 +34,7 @@ using TechnitiumLibrary.Net.Dns.ResourceRecords;
 
 namespace QueryLogsMySql
 {
-    public sealed class App : IDnsApplication, IDnsQueryLogger, IDnsQueryLogs
+    public sealed class App : IDnsApplication, IDnsQueryLoggerEx, IDnsQueryLogs
     {
         #region variables
 
@@ -216,14 +216,14 @@ namespace QueryLogsMySql
                     await using (MySqlCommand command = connection.CreateCommand())
                     {
                         sb.Length = 0;
-                        sb.Append("INSERT INTO dns_logs (server, timestamp, client_ip, protocol, response_type, response_rtt, rcode, qname, qtype, qclass, answer) VALUES ");
+                        sb.Append("INSERT INTO dns_logs (server, timestamp, client_ip, protocol, response_type, response_rtt, rcode, qname, qtype, qclass, answer, blocking_metadata) VALUES ");
 
                         for (int i = 0; i < logs.Count; i++)
                         {
                             if (i == 0)
-                                sb.Append($"(@server{i}, @timestamp{i}, @client_ip{i}, @protocol{i}, @response_type{i}, @response_rtt{i}, @rcode{i}, @qname{i}, @qtype{i}, @qclass{i}, @answer{i})");
+                                sb.Append($"(@server{i}, @timestamp{i}, @client_ip{i}, @protocol{i}, @response_type{i}, @response_rtt{i}, @rcode{i}, @qname{i}, @qtype{i}, @qclass{i}, @answer{i}, @blocking_metadata{i})");
                             else
-                                sb.Append($", (@server{i}, @timestamp{i}, @client_ip{i}, @protocol{i}, @response_type{i}, @response_rtt{i}, @rcode{i}, @qname{i}, @qtype{i}, @qclass{i}, @answer{i})");
+                                sb.Append($", (@server{i}, @timestamp{i}, @client_ip{i}, @protocol{i}, @response_type{i}, @response_rtt{i}, @rcode{i}, @qname{i}, @qtype{i}, @qclass{i}, @answer{i}, @blocking_metadata{i})");
                         }
                         command.CommandText = sb.ToString();
 
@@ -242,18 +242,14 @@ namespace QueryLogsMySql
                             MySqlParameter paramQtype = command.Parameters.Add("@qtype" + i, MySqlDbType.Int16);
                             MySqlParameter paramQclass = command.Parameters.Add("@qclass" + i, MySqlDbType.Int16);
                             MySqlParameter paramAnswer = command.Parameters.Add("@answer" + i, MySqlDbType.VarChar);
+                            MySqlParameter paramBlockingMetadata = command.Parameters.Add("@blocking_metadata" + i, MySqlDbType.Text);
 
                             paramServer.Value = _dnsServer?.ServerDomain;
                             paramTimestamp.Value = log.Timestamp;
                             paramClientIp.Value = log.RemoteEP.Address.ToString();
                             paramProtocol.Value = (byte)log.Protocol;
 
-                            DnsServerResponseType responseType;
-
-                            if (log.Response.Tag == null)
-                                responseType = DnsServerResponseType.Recursive;
-                            else
-                                responseType = (DnsServerResponseType)log.Response.Tag;
+                            DnsServerResponseType responseType = DnsServerResponseTag.GetResponseType(log.Response.Tag);
 
                             paramResponseType.Value = (byte)responseType;
 
@@ -304,6 +300,11 @@ namespace QueryLogsMySql
 
                                 paramAnswer.Value = answer;
                             }
+
+                            if (log.Metadata is null)
+                                paramBlockingMetadata.Value = DBNull.Value;
+                            else
+                                paramBlockingMetadata.Value = JsonSerializer.Serialize(log.Metadata.Values);
                         }
 
                         await command.ExecuteNonQueryAsync();
@@ -375,7 +376,8 @@ CREATE TABLE IF NOT EXISTS dns_logs
     qname VARCHAR(255),
     qtype SMALLINT,
     qclass SMALLINT,
-    answer VARCHAR(4000)
+    answer VARCHAR(4000),
+    blocking_metadata TEXT
 );
 ";
 
@@ -397,6 +399,18 @@ CREATE TABLE IF NOT EXISTS dns_logs
                             await using (MySqlCommand command = connection.CreateCommand())
                             {
                                 command.CommandText = "ALTER TABLE dns_logs MODIFY protocol TINYINT UNSIGNED NOT NULL;";
+
+                                try
+                                {
+                                    await command.ExecuteNonQueryAsync();
+                                }
+                                catch
+                                { }
+                            }
+
+                            await using (MySqlCommand command = connection.CreateCommand())
+                            {
+                                command.CommandText = "ALTER TABLE dns_logs ADD blocking_metadata TEXT;";
 
                                 try
                                 {
@@ -667,8 +681,13 @@ CREATE TABLE IF NOT EXISTS dns_logs
 
         public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response)
         {
+            return InsertLogAsync(timestamp, request, remoteEP, protocol, response, null);
+        }
+
+        public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata)
+        {
             if (_enableLogging)
-                _channelWriter?.TryWrite(new LogEntry(timestamp, request, remoteEP, protocol, response));
+                _channelWriter?.TryWrite(new LogEntry(timestamp, request, remoteEP, protocol, response, metadata));
 
             return Task.CompletedTask;
         }
@@ -892,18 +911,20 @@ ORDER BY row_num" + (descendingOrder ? " DESC" : "");
             public readonly IPEndPoint RemoteEP;
             public readonly DnsTransportProtocol Protocol;
             public readonly DnsDatagram Response;
+            public readonly DnsQueryLogMetadata? Metadata;
 
             #endregion
 
             #region constructor
 
-            public LogEntry(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response)
+            public LogEntry(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata = null)
             {
                 Timestamp = timestamp;
                 Request = request;
                 RemoteEP = remoteEP;
                 Protocol = protocol;
                 Response = response;
+                Metadata = metadata;
             }
 
             #endregion

--- a/Apps/QueryLogsMySqlApp/App.cs
+++ b/Apps/QueryLogsMySqlApp/App.cs
@@ -924,7 +924,7 @@ ORDER BY row_num" + (descendingOrder ? " DESC" : "");
                 RemoteEP = remoteEP;
                 Protocol = protocol;
                 Response = response;
-                Metadata = metadata;
+                Metadata = metadata ?? DnsServerResponseTag.GetLogMetadata(response.Tag);
             }
 
             #endregion

--- a/Apps/QueryLogsSqlServerApp/App.cs
+++ b/Apps/QueryLogsSqlServerApp/App.cs
@@ -825,7 +825,7 @@ ORDER BY row_num" + (descendingOrder ? " DESC" : "");
                 RemoteEP = remoteEP;
                 Protocol = protocol;
                 Response = response;
-                Metadata = metadata;
+                Metadata = metadata ?? DnsServerResponseTag.GetLogMetadata(response.Tag);
             }
 
             #endregion

--- a/Apps/QueryLogsSqlServerApp/App.cs
+++ b/Apps/QueryLogsSqlServerApp/App.cs
@@ -390,7 +390,7 @@ BEGIN
         qtype SMALLINT,
         qclass SMALLINT,
         answer VARCHAR(4000),
-        blocking_metadata VARCHAR(MAX)
+        blocking_metadata NVARCHAR(MAX)
     );
 END
 
@@ -401,7 +401,18 @@ END
 
 IF NOT EXISTS(SELECT * FROM sys.columns WHERE name = 'blocking_metadata' AND object_id = OBJECT_ID('dns_logs'))
 BEGIN
-    ALTER TABLE dns_logs ADD blocking_metadata VARCHAR(MAX);
+    ALTER TABLE dns_logs ADD blocking_metadata NVARCHAR(MAX);
+END
+ELSE IF EXISTS
+(
+    SELECT *
+    FROM sys.columns
+    WHERE object_id = OBJECT_ID('dns_logs')
+      AND name = 'blocking_metadata'
+      AND system_type_id = 167
+)
+BEGIN
+    ALTER TABLE dns_logs ALTER COLUMN blocking_metadata NVARCHAR(MAX);
 END
 
 IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'index_server' AND object_id = OBJECT_ID('dns_logs'))

--- a/Apps/QueryLogsSqlServerApp/App.cs
+++ b/Apps/QueryLogsSqlServerApp/App.cs
@@ -34,7 +34,7 @@ using TechnitiumLibrary.Net.Dns.ResourceRecords;
 
 namespace QueryLogsSqlServer
 {
-    public sealed class App : IDnsApplication, IDnsQueryLogger, IDnsQueryLogs
+    public sealed class App : IDnsApplication, IDnsQueryLoggerEx, IDnsQueryLogs
     {
         #region variables
 
@@ -50,7 +50,7 @@ namespace QueryLogsSqlServer
         Channel<LogEntry>? _channel;
         ChannelWriter<LogEntry>? _channelWriter;
         Thread? _consumerThread;
-        const int BULK_INSERT_COUNT = 190; //sql server supports a maximum of 2100 parameters per query
+        const int BULK_INSERT_COUNT = 175; //sql server supports a maximum of 2100 parameters per query
         const int BULK_INSERT_ERROR_DELAY = 10000;
 
         readonly Timer _cleanupTimer;
@@ -216,14 +216,14 @@ namespace QueryLogsSqlServer
                     await using (SqlCommand command = connection.CreateCommand())
                     {
                         sb.Length = 0;
-                        sb.Append("INSERT INTO dns_logs (server, timestamp, client_ip, protocol, response_type, response_rtt, rcode, qname, qtype, qclass, answer) VALUES ");
+                        sb.Append("INSERT INTO dns_logs (server, timestamp, client_ip, protocol, response_type, response_rtt, rcode, qname, qtype, qclass, answer, blocking_metadata) VALUES ");
 
                         for (int i = 0; i < logs.Count; i++)
                         {
                             if (i == 0)
-                                sb.Append($"(@server{i}, @timestamp{i}, @client_ip{i}, @protocol{i}, @response_type{i}, @response_rtt{i}, @rcode{i}, @qname{i}, @qtype{i}, @qclass{i}, @answer{i})");
+                                sb.Append($"(@server{i}, @timestamp{i}, @client_ip{i}, @protocol{i}, @response_type{i}, @response_rtt{i}, @rcode{i}, @qname{i}, @qtype{i}, @qclass{i}, @answer{i}, @blocking_metadata{i})");
                             else
-                                sb.Append($", (@server{i}, @timestamp{i}, @client_ip{i}, @protocol{i}, @response_type{i}, @response_rtt{i}, @rcode{i}, @qname{i}, @qtype{i}, @qclass{i}, @answer{i})");
+                                sb.Append($", (@server{i}, @timestamp{i}, @client_ip{i}, @protocol{i}, @response_type{i}, @response_rtt{i}, @rcode{i}, @qname{i}, @qtype{i}, @qclass{i}, @answer{i}, @blocking_metadata{i})");
                         }
 
                         command.CommandText = sb.ToString();
@@ -243,18 +243,14 @@ namespace QueryLogsSqlServer
                             SqlParameter paramQtype = command.Parameters.Add("@qtype" + i, SqlDbType.SmallInt);
                             SqlParameter paramQclass = command.Parameters.Add("@qclass" + i, SqlDbType.SmallInt);
                             SqlParameter paramAnswer = command.Parameters.Add("@answer" + i, SqlDbType.VarChar);
+                            SqlParameter paramBlockingMetadata = command.Parameters.Add("@blocking_metadata" + i, SqlDbType.NVarChar, -1);
 
                             paramServer.Value = _dnsServer?.ServerDomain;
                             paramTimestamp.Value = log.Timestamp;
                             paramClientIp.Value = log.RemoteEP.Address.ToString();
                             paramProtocol.Value = (byte)log.Protocol;
 
-                            DnsServerResponseType responseType;
-
-                            if (log.Response.Tag == null)
-                                responseType = DnsServerResponseType.Recursive;
-                            else
-                                responseType = (DnsServerResponseType)log.Response.Tag;
+                            DnsServerResponseType responseType = DnsServerResponseTag.GetResponseType(log.Response.Tag);
 
                             paramResponseType.Value = (byte)responseType;
 
@@ -305,6 +301,11 @@ namespace QueryLogsSqlServer
 
                                 paramAnswer.Value = answer;
                             }
+
+                            if (log.Metadata is null)
+                                paramBlockingMetadata.Value = DBNull.Value;
+                            else
+                                paramBlockingMetadata.Value = JsonSerializer.Serialize(log.Metadata.Values);
                         }
 
                         await command.ExecuteNonQueryAsync();
@@ -388,13 +389,19 @@ BEGIN
         qname VARCHAR(255),
         qtype SMALLINT,
         qclass SMALLINT,
-        answer VARCHAR(4000)
+        answer VARCHAR(4000),
+        blocking_metadata VARCHAR(MAX)
     );
 END
 
 IF NOT EXISTS(SELECT * FROM sys.columns WHERE name = 'server' AND object_id = OBJECT_ID('dns_logs'))
 BEGIN
     ALTER TABLE dns_logs ADD server varchar(255);
+END
+
+IF NOT EXISTS(SELECT * FROM sys.columns WHERE name = 'blocking_metadata' AND object_id = OBJECT_ID('dns_logs'))
+BEGIN
+    ALTER TABLE dns_logs ADD blocking_metadata VARCHAR(MAX);
 END
 
 IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'index_server' AND object_id = OBJECT_ID('dns_logs'))
@@ -563,8 +570,13 @@ END
 
         public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response)
         {
+            return InsertLogAsync(timestamp, request, remoteEP, protocol, response, null);
+        }
+
+        public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata)
+        {
             if (_enableLogging)
-                _channelWriter?.TryWrite(new LogEntry(timestamp, request, remoteEP, protocol, response));
+                _channelWriter?.TryWrite(new LogEntry(timestamp, request, remoteEP, protocol, response, metadata));
 
             return Task.CompletedTask;
         }
@@ -789,18 +801,20 @@ ORDER BY row_num" + (descendingOrder ? " DESC" : "");
             public readonly IPEndPoint RemoteEP;
             public readonly DnsTransportProtocol Protocol;
             public readonly DnsDatagram Response;
+            public readonly DnsQueryLogMetadata? Metadata;
 
             #endregion
 
             #region constructor
 
-            public LogEntry(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response)
+            public LogEntry(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata = null)
             {
                 Timestamp = timestamp;
                 Request = request;
                 RemoteEP = remoteEP;
                 Protocol = protocol;
                 Response = response;
+                Metadata = metadata;
             }
 
             #endregion

--- a/Apps/QueryLogsSqliteApp/App.cs
+++ b/Apps/QueryLogsSqliteApp/App.cs
@@ -34,7 +34,7 @@ using TechnitiumLibrary.Net.Dns.ResourceRecords;
 
 namespace QueryLogsSqlite
 {
-    public sealed class App : IDnsApplication, IDnsQueryLogger, IDnsQueryLogs
+    public sealed class App : IDnsApplication, IDnsQueryLoggerEx, IDnsQueryLogs
     {
         #region variables
 
@@ -226,7 +226,7 @@ namespace QueryLogsSqlite
                     {
                         await using (SqliteCommand command = connection.CreateCommand())
                         {
-                            command.CommandText = "INSERT INTO dns_logs (timestamp, client_ip, protocol, response_type, response_rtt, rcode, qname, qtype, qclass, answer) VALUES (@timestamp, @client_ip, @protocol, @response_type, @response_rtt, @rcode, @qname, @qtype, @qclass, @answer);";
+                            command.CommandText = "INSERT INTO dns_logs (timestamp, client_ip, protocol, response_type, response_rtt, rcode, qname, qtype, qclass, answer, blocking_metadata) VALUES (@timestamp, @client_ip, @protocol, @response_type, @response_rtt, @rcode, @qname, @qtype, @qclass, @answer, @blocking_metadata);";
 
                             SqliteParameter paramTimestamp = command.Parameters.Add("@timestamp", SqliteType.Text);
                             SqliteParameter paramClientIp = command.Parameters.Add("@client_ip", SqliteType.Text);
@@ -238,6 +238,7 @@ namespace QueryLogsSqlite
                             SqliteParameter paramQtype = command.Parameters.Add("@qtype", SqliteType.Integer);
                             SqliteParameter paramQclass = command.Parameters.Add("@qclass", SqliteType.Integer);
                             SqliteParameter paramAnswer = command.Parameters.Add("@answer", SqliteType.Text);
+                            SqliteParameter paramBlockingMetadata = command.Parameters.Add("@blocking_metadata", SqliteType.Text);
 
                             foreach (LogEntry log in logs)
                             {
@@ -245,12 +246,7 @@ namespace QueryLogsSqlite
                                 paramClientIp.Value = log.RemoteEP.Address.ToString();
                                 paramProtocol.Value = (int)log.Protocol;
 
-                                DnsServerResponseType responseType;
-
-                                if (log.Response.Tag == null)
-                                    responseType = DnsServerResponseType.Recursive;
-                                else
-                                    responseType = (DnsServerResponseType)log.Response.Tag;
+                                DnsServerResponseType responseType = DnsServerResponseTag.GetResponseType(log.Response.Tag);
 
                                 paramResponseType.Value = (int)responseType;
 
@@ -298,6 +294,11 @@ namespace QueryLogsSqlite
 
                                     paramAnswer.Value = answer;
                                 }
+
+                                if (log.Metadata is null)
+                                    paramBlockingMetadata.Value = DBNull.Value;
+                                else
+                                    paramBlockingMetadata.Value = JsonSerializer.Serialize(log.Metadata.Values);
 
                                 await command.ExecuteNonQueryAsync();
                             }
@@ -386,7 +387,8 @@ CREATE TABLE IF NOT EXISTS dns_logs
     qname VARCHAR(255),
     qtype SMALLINT,
     qclass SMALLINT,
-    answer TEXT
+    answer TEXT,
+    blocking_metadata TEXT
 );
 ";
                     await command.ExecuteNonQueryAsync();
@@ -397,6 +399,17 @@ CREATE TABLE IF NOT EXISTS dns_logs
                     await using (SqliteCommand command = connection.CreateCommand())
                     {
                         command.CommandText = "ALTER TABLE dns_logs ADD COLUMN response_rtt REAL;";
+                        await command.ExecuteNonQueryAsync();
+                    }
+                }
+                catch
+                { }
+
+                try
+                {
+                    await using (SqliteCommand command = connection.CreateCommand())
+                    {
+                        command.CommandText = "ALTER TABLE dns_logs ADD COLUMN blocking_metadata TEXT;";
                         await command.ExecuteNonQueryAsync();
                     }
                 }
@@ -524,8 +537,13 @@ CREATE TABLE IF NOT EXISTS dns_logs
 
         public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response)
         {
+            return InsertLogAsync(timestamp, request, remoteEP, protocol, response, null);
+        }
+
+        public Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata)
+        {
             if (_enableLogging)
-                _channelWriter?.TryWrite(new LogEntry(timestamp, request, remoteEP, protocol, response));
+                _channelWriter?.TryWrite(new LogEntry(timestamp, request, remoteEP, protocol, response, metadata));
 
             return Task.CompletedTask;
         }
@@ -750,18 +768,20 @@ ORDER BY row_num" + (descendingOrder ? " DESC" : "");
             public readonly IPEndPoint RemoteEP;
             public readonly DnsTransportProtocol Protocol;
             public readonly DnsDatagram Response;
+            public readonly DnsQueryLogMetadata? Metadata;
 
             #endregion
 
             #region constructor
 
-            public LogEntry(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response)
+            public LogEntry(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata = null)
             {
                 Timestamp = timestamp;
                 Request = request;
                 RemoteEP = remoteEP;
                 Protocol = protocol;
                 Response = response;
+                Metadata = metadata;
             }
 
             #endregion

--- a/Apps/QueryLogsSqliteApp/App.cs
+++ b/Apps/QueryLogsSqliteApp/App.cs
@@ -781,7 +781,7 @@ ORDER BY row_num" + (descendingOrder ? " DESC" : "");
                 RemoteEP = remoteEP;
                 Protocol = protocol;
                 Response = response;
-                Metadata = metadata;
+                Metadata = metadata ?? DnsServerResponseTag.GetLogMetadata(response.Tag);
             }
 
             #endregion

--- a/DnsServerCore.ApplicationCommon/IDnsQueryLogger.cs
+++ b/DnsServerCore.ApplicationCommon/IDnsQueryLogger.cs
@@ -43,7 +43,7 @@ namespace DnsServerCore.ApplicationCommon
             if (Values.Count < 1)
                 return string.Empty;
 
-            return string.Join("; ", Values.Select(kv => kv.Key + "=" + kv.Value));
+            return string.Join("; ", Values.Select(kv => Uri.EscapeDataString(kv.Key) + "=" + Uri.EscapeDataString(kv.Value)));
         }
 
         public static DnsQueryLogMetadata? ParseReportString(string? report)
@@ -65,6 +65,16 @@ namespace DnsServerCore.ApplicationCommon
 
                 string key = part[..separatorIndex].Trim();
                 string value = part[(separatorIndex + 1)..].Trim();
+
+                try
+                {
+                    key = Uri.UnescapeDataString(key);
+                    value = Uri.UnescapeDataString(value);
+                }
+                catch
+                {
+                    continue;
+                }
 
                 if ((key.Length < 1) || (value.Length < 1))
                     continue;

--- a/DnsServerCore.ApplicationCommon/IDnsQueryLogger.cs
+++ b/DnsServerCore.ApplicationCommon/IDnsQueryLogger.cs
@@ -18,12 +18,104 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using TechnitiumLibrary.Net.Dns;
 
 namespace DnsServerCore.ApplicationCommon
 {
+    public sealed class DnsQueryLogMetadata
+    {
+        public DnsQueryLogMetadata(IReadOnlyDictionary<string, string>? values = null)
+        {
+            Values = values is null ? new Dictionary<string, string>(0) : new Dictionary<string, string>(values, StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Structured metadata key/value pairs (example keys: <c>source</c>, <c>domain</c>, <c>blockListUrl</c>).
+        /// </summary>
+        public IReadOnlyDictionary<string, string> Values { get; }
+
+        public string ToReportString()
+        {
+            if (Values.Count < 1)
+                return string.Empty;
+
+            return string.Join("; ", Values.Select(kv => kv.Key + "=" + kv.Value));
+        }
+
+        public static DnsQueryLogMetadata? ParseReportString(string? report)
+        {
+            if (string.IsNullOrWhiteSpace(report))
+                return null;
+
+            string[] parts = report.Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 1)
+                return null;
+
+            Dictionary<string, string> values = new Dictionary<string, string>(parts.Length, StringComparer.OrdinalIgnoreCase);
+
+            foreach (string part in parts)
+            {
+                int separatorIndex = part.IndexOf('=');
+                if ((separatorIndex < 1) || (separatorIndex >= (part.Length - 1)))
+                    continue;
+
+                string key = part[..separatorIndex].Trim();
+                string value = part[(separatorIndex + 1)..].Trim();
+
+                if ((key.Length < 1) || (value.Length < 1))
+                    continue;
+
+                values[key] = value;
+            }
+
+            if (values.Count < 1)
+                return null;
+
+            return new DnsQueryLogMetadata(values);
+        }
+    }
+
+    public sealed class DnsServerResponseMetadata
+    {
+        public DnsServerResponseMetadata(DnsServerResponseType responseType, DnsQueryLogMetadata? logMetadata = null)
+        {
+            ResponseType = responseType;
+            LogMetadata = logMetadata;
+        }
+
+        public DnsServerResponseType ResponseType { get; }
+        public DnsQueryLogMetadata? LogMetadata { get; }
+    }
+
+    public static class DnsServerResponseTag
+    {
+        public static DnsServerResponseType GetResponseType(object? tag)
+        {
+            if (tag is null)
+                return DnsServerResponseType.Recursive;
+
+            if (tag is DnsServerResponseType responseType)
+                return responseType;
+
+            if (tag is DnsServerResponseMetadata responseMetadata)
+                return responseMetadata.ResponseType;
+
+            return DnsServerResponseType.Recursive;
+        }
+
+        public static DnsQueryLogMetadata? GetLogMetadata(object? tag)
+        {
+            if (tag is DnsServerResponseMetadata responseMetadata)
+                return responseMetadata.LogMetadata;
+
+            return null;
+        }
+    }
+
     public enum DnsServerResponseType : byte
     {
         Authoritative = 1,
@@ -49,5 +141,22 @@ namespace DnsServerCore.ApplicationCommon
         /// <param name="protocol">The protocol using which the request was received.</param>
         /// <param name="response">The DNS response that was sent.</param>
         Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response);
+    }
+
+    /// <summary>
+    /// Allows a DNS App to receive extended query log metadata.
+    /// </summary>
+    public interface IDnsQueryLoggerEx : IDnsQueryLogger
+    {
+        /// <summary>
+        /// Allows a DNS App to log incoming DNS requests and responses, including metadata that may not be present in the wire response.
+        /// </summary>
+        /// <param name="timestamp">The time stamp of the log entry.</param>
+        /// <param name="request">The incoming DNS request that was received.</param>
+        /// <param name="remoteEP">The end point (IP address and port) of the client making the request.</param>
+        /// <param name="protocol">The protocol using which the request was received.</param>
+        /// <param name="response">The DNS response that was sent.</param>
+        /// <param name="metadata">Optional metadata for logging.</param>
+        Task InsertLogAsync(DateTime timestamp, DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol, DnsDatagram response, DnsQueryLogMetadata? metadata);
     }
 }

--- a/DnsServerCore/Dns/DnsServer.cs
+++ b/DnsServerCore/Dns/DnsServer.cs
@@ -4009,7 +4009,19 @@ namespace DnsServerCore.Dns
             return false;
         }
 
-        private async Task<DnsDatagram> ProcessBlockedQueryAsync(DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol)
+        sealed class BlockedQueryResult
+        {
+            public BlockedQueryResult(DnsDatagram response, DnsQueryLogMetadata? logMetadata = null)
+            {
+                Response = response;
+                LogMetadata = logMetadata;
+            }
+
+            public DnsDatagram Response { get; }
+            public DnsQueryLogMetadata? LogMetadata { get; }
+        }
+
+        private async Task<BlockedQueryResult> ProcessBlockedQueryAsync(DnsDatagram request, IPEndPoint remoteEP, DnsTransportProtocol protocol)
         {
             if (_enableBlocking)
             {
@@ -4017,12 +4029,21 @@ namespace DnsServerCore.Dns
                 if (response is null)
                 {
                     //domain not blocked in blocked zone
-                    response = _blockListZoneManager.Query(request); //check in block list zone
+                    response = _blockListZoneManager.Query(request, out DnsQueryLogMetadata blockListLogMetadata); //check in block list zone
                     if (response is not null)
                     {
                         //domain is blocked in block list zone
-                        response.Tag = DnsServerResponseType.Blocked;
-                        return response;
+                        if (response.Tag is null)
+                        {
+                            string blockedDomain = request.Question[0].Name;
+                            DnsResourceRecord firstAuthority = response.FindFirstAuthorityRecord();
+                            if ((firstAuthority is not null) && (firstAuthority.Type == DnsResourceRecordType.SOA))
+                                blockedDomain = firstAuthority.Name;
+
+                            response.Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, new DnsQueryLogMetadata(new Dictionary<string, string>(2, StringComparer.OrdinalIgnoreCase) { ["source"] = "block-list-zone", ["domain"] = blockedDomain }));
+                        }
+
+                        return new BlockedQueryResult(response, blockListLogMetadata ?? DnsServerResponseTag.GetLogMetadata(response.Tag));
                     }
 
                     //domain not blocked in block list zone; continue to check app blocking handlers
@@ -4045,20 +4066,21 @@ namespace DnsServerCore.Dns
                     {
                         //return meta data
                         string blockedDomain = GetBlockedDomain();
+                        DnsQueryLogMetadata logMetadata = new DnsQueryLogMetadata(new Dictionary<string, string>(2, StringComparer.OrdinalIgnoreCase) { ["source"] = "blocked-zone", ["domain"] = blockedDomain });
 
-                        IReadOnlyList<DnsResourceRecord> answer = [new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, _blockingAnswerTtl, new DnsTXTRecordData("source=blocked-zone; domain=" + blockedDomain))];
+                        IReadOnlyList<DnsResourceRecord> answer = [new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, _blockingAnswerTtl, new DnsTXTRecordData(logMetadata.ToReportString()))];
 
-                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer) { Tag = DnsServerResponseType.Blocked };
+                        return new BlockedQueryResult(new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) }, logMetadata);
                     }
                     else
                     {
-                        string blockedDomain = null;
+                        string blockedDomain = GetBlockedDomain();
                         EDnsOption[] options = null;
+                        DnsQueryLogMetadata logMetadata = new DnsQueryLogMetadata(new Dictionary<string, string>(2, StringComparer.OrdinalIgnoreCase) { ["source"] = "blocked-zone", ["domain"] = blockedDomain });
 
                         if (_allowTxtBlockingReport && (request.EDNS is not null))
                         {
-                            blockedDomain = GetBlockedDomain();
-                            options = [new EDnsOption(EDnsOptionCode.EXTENDED_DNS_ERROR, new EDnsExtendedDnsErrorOptionData(EDnsExtendedDnsErrorCode.Blocked, "source=blocked-zone; domain=" + blockedDomain))];
+                            options = [new EDnsOption(EDnsOptionCode.EXTENDED_DNS_ERROR, new EDnsExtendedDnsErrorOptionData(EDnsExtendedDnsErrorCode.Blocked, logMetadata.ToReportString()))];
                         }
 
                         IReadOnlyCollection<DnsARecordData> aRecords;
@@ -4077,14 +4099,11 @@ namespace DnsServerCore.Dns
                                 break;
 
                             case DnsServerBlockingType.NxDomain:
-                                if (blockedDomain is null)
-                                    blockedDomain = GetBlockedDomain();
-
                                 string parentDomain = AuthZoneManager.GetParentZone(blockedDomain);
                                 if (parentDomain is null)
                                     parentDomain = string.Empty;
 
-                                return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NxDomain, request.Question, null, [new DnsResourceRecord(parentDomain, DnsResourceRecordType.SOA, question.Class, _blockingAnswerTtl, _blockedZoneManager.DnsSOARecord)], null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = DnsServerResponseType.Blocked };
+                                return new BlockedQueryResult(new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NxDomain, request.Question, null, [new DnsResourceRecord(parentDomain, DnsResourceRecordType.SOA, question.Class, _blockingAnswerTtl, _blockedZoneManager.DnsSOARecord)], null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) }, logMetadata);
 
                             default:
                                 throw new InvalidOperationException();
@@ -4141,7 +4160,7 @@ namespace DnsServerCore.Dns
                                 break;
                         }
 
-                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer, authority, null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = DnsServerResponseType.Blocked };
+                        return new BlockedQueryResult(new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer, authority, null, request.EDNS is null ? ushort.MinValue : _udpPayloadSize, EDnsHeaderFlags.None, options) { Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, logMetadata) }, logMetadata);
                     }
                 }
             }
@@ -4154,9 +4173,9 @@ namespace DnsServerCore.Dns
                     if (appBlockedResponse is not null)
                     {
                         if (appBlockedResponse.Tag is null)
-                            appBlockedResponse.Tag = DnsServerResponseType.Blocked;
+                            appBlockedResponse.Tag = new DnsServerResponseMetadata(DnsServerResponseType.Blocked);
 
-                        return appBlockedResponse;
+                        return new BlockedQueryResult(appBlockedResponse, DnsServerResponseTag.GetLogMetadata(appBlockedResponse.Tag));
                     }
                 }
                 catch (Exception ex)
@@ -4183,9 +4202,9 @@ namespace DnsServerCore.Dns
                 isAllowed = await IsAllowedAsync(request, remoteEP, protocol);
                 if (!isAllowed)
                 {
-                    DnsDatagram blockedResponse = await ProcessBlockedQueryAsync(request, remoteEP, protocol);
+                    BlockedQueryResult blockedResponse = await ProcessBlockedQueryAsync(request, remoteEP, protocol);
                     if (blockedResponse is not null)
-                        return blockedResponse;
+                        return blockedResponse.Response;
                 }
             }
 
@@ -4226,7 +4245,7 @@ namespace DnsServerCore.Dns
                             break; //CNAME is in allowed zone
 
                         //check blocked zone and block list zone
-                        DnsDatagram blockedResponse = await ProcessBlockedQueryAsync(newRequest, remoteEP, protocol);
+                        BlockedQueryResult blockedResponse = await ProcessBlockedQueryAsync(newRequest, remoteEP, protocol);
                         if (blockedResponse is not null)
                         {
                             //found cname cloaking
@@ -4237,21 +4256,26 @@ namespace DnsServerCore.Dns
                                 answer.Add(response.Answer[j]);
 
                             //copy last response answers
-                            answer.AddRange(blockedResponse.Answer);
+                            answer.AddRange(blockedResponse.Response.Answer);
 
                             //include blocked response additional section to pass on Extended DNS Errors
-                            return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, true, true, false, false, blockedResponse.RCODE, request.Question, answer, blockedResponse.Authority, blockedResponse.Additional) { Tag = blockedResponse.Tag };
+                            return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, true, true, false, false, blockedResponse.Response.RCODE, request.Question, answer, blockedResponse.Response.Authority, blockedResponse.Response.Additional)
+                            {
+                                Tag = blockedResponse.LogMetadata is null ? blockedResponse.Response.Tag : new DnsServerResponseMetadata(DnsServerResponseType.Blocked, blockedResponse.LogMetadata)
+                            };
                         }
                     }
                 }
             }
+
+            DnsServerResponseType responseType = DnsServerResponseTag.GetResponseType(response.Tag);
 
             if (response.Tag is null)
             {
                 if (response.IsBlockedResponse())
                     response.Tag = DnsServerResponseType.UpstreamBlocked;
             }
-            else if ((DnsServerResponseType)response.Tag == DnsServerResponseType.Cached)
+            else if (responseType == DnsServerResponseType.Cached)
             {
                 if (response.IsBlockedResponse())
                     response.Tag = DnsServerResponseType.UpstreamBlockedCached;

--- a/DnsServerCore/Dns/StatsManager.cs
+++ b/DnsServerCore/Dns/StatsManager.cs
@@ -141,10 +141,8 @@ namespace DnsServerCore.Dns
 
                             if (item._response is null)
                                 responseType = DnsServerResponseType.Dropped;
-                            else if (item._response.Tag is null)
-                                responseType = DnsServerResponseType.Recursive;
                             else
-                                responseType = (DnsServerResponseType)item._response.Tag;
+                                responseType = DnsServerResponseTag.GetResponseType(item._response.Tag);
 
                             statCounter.Update(query, item._response is null ? DnsResponseCode.NoError : item._response.RCODE, responseType, item._remoteEP.Address, item._protocol, item._rateLimited);
                         }
@@ -156,7 +154,12 @@ namespace DnsServerCore.Dns
                         {
                             try
                             {
-                                _ = logger.InsertLogAsync(item._timestamp, item._request, item._remoteEP, item._protocol, item._response);
+                                DnsQueryLogMetadata? logMetadata = DnsServerResponseTag.GetLogMetadata(item._response.Tag);
+
+                                if (logger is IDnsQueryLoggerEx loggerEx)
+                                    _ = loggerEx.InsertLogAsync(item._timestamp, item._request, item._remoteEP, item._protocol, item._response, logMetadata);
+                                else
+                                    _ = logger.InsertLogAsync(item._timestamp, item._request, item._remoteEP, item._protocol, item._response);
                             }
                             catch (Exception ex)
                             {

--- a/DnsServerCore/Dns/ZoneManagers/BlockListZoneManager.cs
+++ b/DnsServerCore/Dns/ZoneManagers/BlockListZoneManager.cs
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 */
 
+using DnsServerCore.ApplicationCommon;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -839,8 +840,10 @@ namespace DnsServerCore.Dns.ZoneManagers
             return IsZoneAllowed(request.Question[0].Name);
         }
 
-        public DnsDatagram Query(DnsDatagram request)
+        public DnsDatagram Query(DnsDatagram request, out DnsQueryLogMetadata logMetadata)
         {
+            logMetadata = null;
+
             if (_blockListZone.Count < 1)
                 return null;
 
@@ -849,6 +852,21 @@ namespace DnsServerCore.Dns.ZoneManagers
             List<Uri> blockLists = IsZoneBlocked(question.Name, out string blockedDomain);
             if (blockLists is null)
                 return null; //zone not blocked
+
+            Dictionary<string, string> metadataValues = new Dictionary<string, string>(4, StringComparer.OrdinalIgnoreCase)
+            {
+                ["source"] = "block-list-zone",
+                ["domain"] = blockedDomain
+            };
+
+            if (blockLists.Count > 0)
+            {
+                metadataValues["blockListUrl"] = blockLists[0].AbsoluteUri;
+                metadataValues["blockListCount"] = blockLists.Count.ToString();
+            }
+
+            DnsServerResponseMetadata responseMetadata = new DnsServerResponseMetadata(DnsServerResponseType.Blocked, new DnsQueryLogMetadata(metadataValues));
+            logMetadata = responseMetadata.LogMetadata;
 
             //zone is blocked
             if (_dnsServer.AllowTxtBlockingReport && (question.Type == DnsResourceRecordType.TXT))
@@ -859,7 +877,7 @@ namespace DnsServerCore.Dns.ZoneManagers
                 for (int i = 0; i < answer.Length; i++)
                     answer[i] = new DnsResourceRecord(question.Name, DnsResourceRecordType.TXT, question.Class, _dnsServer.BlockingAnswerTtl, new DnsTXTRecordData("source=block-list-zone; blockListUrl=" + blockLists[i].AbsoluteUri + "; domain=" + blockedDomain));
 
-                return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer);
+                return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer) { Tag = responseMetadata };
             }
             else
             {
@@ -893,7 +911,7 @@ namespace DnsServerCore.Dns.ZoneManagers
                         if (parentDomain is null)
                             parentDomain = string.Empty;
 
-                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NxDomain, request.Question, null, [new DnsResourceRecord(parentDomain, DnsResourceRecordType.SOA, question.Class, _dnsServer.BlockingAnswerTtl, _soaRecord)], null, request.EDNS is null ? ushort.MinValue : _dnsServer.UdpPayloadSize, EDnsHeaderFlags.None, options);
+                        return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NxDomain, request.Question, null, [new DnsResourceRecord(parentDomain, DnsResourceRecordType.SOA, question.Class, _dnsServer.BlockingAnswerTtl, _soaRecord)], null, request.EDNS is null ? ushort.MinValue : _dnsServer.UdpPayloadSize, EDnsHeaderFlags.None, options) { Tag = responseMetadata };
 
                     default:
                         throw new InvalidOperationException();
@@ -959,7 +977,7 @@ namespace DnsServerCore.Dns.ZoneManagers
                         break;
                 }
 
-                return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer, authority, null, request.EDNS is null ? ushort.MinValue : _dnsServer.UdpPayloadSize, EDnsHeaderFlags.None, options);
+                return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, false, false, request.RecursionDesired, false, false, false, DnsResponseCode.NoError, request.Question, answer, authority, null, request.EDNS is null ? ushort.MinValue : _dnsServer.UdpPayloadSize, EDnsHeaderFlags.None, options) { Tag = responseMetadata };
             }
         }
 


### PR DESCRIPTION
### Motivation
- Provide structured metadata for blocked responses so logging/exporting apps can capture why a query was blocked (source, domain, blocklist URL, regex, etc.).
- Ensure the DNS server and apps can attach and forward this metadata end-to-end (zone managers -> server -> stats -> apps -> storage/export).
- Store blocking metadata in query log backends to enable searchable/structured records for blocked queries.

### Description
- Added new types and helpers: `DnsQueryLogMetadata`, `DnsServerResponseMetadata`, and `DnsServerResponseTag` to carry and extract structured blocking metadata and response type.
- Introduced `IDnsQueryLoggerEx` (extends `IDnsQueryLogger`) with an `InsertLogAsync(..., DnsQueryLogMetadata? metadata)` overload and updated `StatsManager` to pass metadata when available to loggers that implement the extended interface.
- Updated DNS server/block handling: `DnsServer`, `BlockListZoneManager`, `AdvancedBlockingApp`, and `MispConnectorApp` now populate `DnsServerResponseMetadata` (including `DnsQueryLogMetadata`) on blocked responses and use the metadata for TXT/EDNS blocking reports.
- Log exporter changes: `LogEntry` now captures blocking metadata, EDNS extended error parsing improved (`Split` limit), and `SyslogExportStrategy` adds blocking fields to exported events.
- Query log backends updated: `QueryLogsMySqlApp`, `QueryLogsSqlServerApp`, and `QueryLogsSqliteApp` accept metadata, include a `blocking_metadata` column in schema/migrations, serialize metadata into bulk inserts, and propagate metadata into channel/queue entries; adjusted `BULK_INSERT_COUNT` for SQL Server.

### Testing
- Performed a full solution build (`dotnet build`) which completed successfully.
- No automated unit tests were added in this change; existing build-time checks succeeded with the modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d212e923208332bffcb2737cdc0c91)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add structured blocking metadata to DNS responses, propagate it to loggers/exporters, and persist it in query log backends. Adds a fallback that pulls metadata from the response tag when not explicitly provided, with metadata strings safely escaped.

- **New Features**
  - Added `DnsQueryLogMetadata`, `DnsServerResponseMetadata`, and `DnsServerResponseTag` to carry response type and blocking details; DNS server builds escaped TXT/EDE reports via `ToReportString()`.
  - Introduced `IDnsQueryLoggerEx` with an `InsertLogAsync` overload that accepts optional metadata; `StatsManager` forwards metadata when available.
  - Populated metadata/tags for blocked responses in `DnsServer`, `BlockListZoneManager` (includes `blockListUrl` and count), `AdvancedBlockingApp`, and `MispConnectorApp`.
  - Log exporter: `LogEntry` captures metadata and falls back to the response tag if none is provided; improved EDNS Extended DNS Error parsing; `SyslogExportStrategy` emits `blocking_*` fields and a `blockingMetadataSummary`.
  - Query log backends (MySQL, SQL Server, SQLite): added `blocking_metadata` column and serialize metadata on inserts; SQL Server uses `NVARCHAR(MAX)` and adjusts bulk insert size to 175.

- **Migration**
  - `IDnsQueryLogger` continues to work; apps can implement `IDnsQueryLoggerEx` to receive metadata.
  - DB backends auto-add `blocking_metadata` on startup; ensure ALTER privileges. SQL Server auto-upgrades existing column to `NVARCHAR(MAX)`.

<sup>Written for commit 711e8bc3c9a8370ec72e1b62a57e96baa60aa5d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

